### PR TITLE
Update Metals to 0.11.10+111-59a1b932-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { pkgs, ... }:
 
-pkgs.metalsBuilder {
+metalsBuilder {
   version = "0.11.10+111-59a1b932-SNAPSHOT";
   outputHash = "sha256-kHiSDRG0HOIZ30y7izvZ0m3GsVt8Mil9lvnrFZiXxHg=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.10+111-59a1b932-SNAPSHOT`. See https://scalameta.org/metals/latests.json