### PR TITLE
Update Metals to 0.11.10+118-2be84509-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.10+117-476976c1-SNAPSHOT";
-  outputHash = "sha256-SX6t9x8F2isMxKFT7Nkafu+bg4MJOTw/6BtEoOyIIrA=";
+  version = "0.11.10+118-2be84509-SNAPSHOT";
+  outputHash = "sha256-81nZLTGX8ZrjKBOZyDglgO1INGKi8rc9pcGOILkM4Bo=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.10+118-2be84509-SNAPSHOT`. See https://scalameta.org/metals/latests.json