### PR TITLE
Update Metals to 0.11.10+121-88866fbb-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.10+118-2be84509-SNAPSHOT";
-  outputHash = "sha256-81nZLTGX8ZrjKBOZyDglgO1INGKi8rc9pcGOILkM4Bo=";
+  version = "0.11.10+121-88866fbb-SNAPSHOT";
+  outputHash = "sha256-Haymz7evRkHLq1iWskT75bYfFjNCTKNSosqHQEynT/8=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.10+121-88866fbb-SNAPSHOT`. See https://scalameta.org/metals/latests.json