### PR TITLE
Update Metals to 0.11.10+126-1ae12fc3-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.10+121-88866fbb-SNAPSHOT";
-  outputHash = "sha256-Haymz7evRkHLq1iWskT75bYfFjNCTKNSosqHQEynT/8=";
+  version = "0.11.10+126-1ae12fc3-SNAPSHOT";
+  outputHash = "sha256-VYkelOKI6fVxMZEVUscsZYGLJXj+Q7+ffqGmqLMMEI4=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.10+126-1ae12fc3-SNAPSHOT`. See https://scalameta.org/metals/latests.json