### PR TITLE
Update Metals to 0.11.10+135-a24dcac5-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.10+126-1ae12fc3-SNAPSHOT";
-  outputHash = "sha256-VYkelOKI6fVxMZEVUscsZYGLJXj+Q7+ffqGmqLMMEI4=";
+  version = "0.11.10+135-a24dcac5-SNAPSHOT";
+  outputHash = "sha256-eo9udv1yJ6wshX9CUOT7ymRkXF8c31sq9wlELW/SUtQ=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.10+135-a24dcac5-SNAPSHOT`. See https://scalameta.org/metals/latests.json