### PR TITLE
Update Metals to 0.11.10+136-6952110f-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.10+135-a24dcac5-SNAPSHOT";
-  outputHash = "sha256-eo9udv1yJ6wshX9CUOT7ymRkXF8c31sq9wlELW/SUtQ=";
+  version = "0.11.10+136-6952110f-SNAPSHOT";
+  outputHash = "sha256-nIbDPKhRJJ4a7O9CskJ4SfWLXsmWGISmv+fWW/uEzSY=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.10+136-6952110f-SNAPSHOT`. See https://scalameta.org/metals/latests.json