### PR TITLE
Update Metals to 0.11.10+141-d22d5a8e-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.10+136-6952110f-SNAPSHOT";
-  outputHash = "sha256-nIbDPKhRJJ4a7O9CskJ4SfWLXsmWGISmv+fWW/uEzSY=";
+  version = "0.11.10+141-d22d5a8e-SNAPSHOT";
+  outputHash = "sha256-d0aJBFZufZOUj+eejNCbmkQsg0XxFlNzK8fCGTje2RU=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.10+141-d22d5a8e-SNAPSHOT`. See https://scalameta.org/metals/latests.json