### PR TITLE
Update Metals to 0.11.10+146-194e6635-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.10+141-d22d5a8e-SNAPSHOT";
-  outputHash = "sha256-d0aJBFZufZOUj+eejNCbmkQsg0XxFlNzK8fCGTje2RU=";
+  version = "0.11.10+146-194e6635-SNAPSHOT";
+  outputHash = "sha256-I7S/jjPphwa+2yBN0vKArFWXfdJCPM59zqLRNrtQEys=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.10+146-194e6635-SNAPSHOT`. See https://scalameta.org/metals/latests.json