### PR TITLE
Update Metals to 0.11.10+155-4d6ef86a-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.10+149-57cfc57e-SNAPSHOT";
-  outputHash = "sha256-BBMNJ9Fs79WyNMxXvtecG0e55QPNS9u9ZGlLongpYXM=";
+  version = "0.11.10+155-4d6ef86a-SNAPSHOT";
+  outputHash = "sha256-L2ZuBG7KqG1A+ASeqGr9UcKDI57ao4H0O905+cf+iII=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.10+155-4d6ef86a-SNAPSHOT`. See https://scalameta.org/metals/latests.json