### PR TITLE
Update Metals to 0.11.10+165-d4feefc2-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.10+156-03062318-SNAPSHOT";
-  outputHash = "sha256-u1M6jiNnB9TVQQQFytmg1s7f2MQunn57IiVNlpHS4qs=";
+  version = "0.11.10+165-d4feefc2-SNAPSHOT";
+  outputHash = "sha256-IQ9qIRKY4OT6cJnp9rnJcqE65/oU6SBFj42lSySjSts=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.10+165-d4feefc2-SNAPSHOT`. See https://scalameta.org/metals/latests.json