### PR TITLE
Update Metals to 0.11.10+166-3a9ab1d7-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.10+165-d4feefc2-SNAPSHOT";
-  outputHash = "sha256-IQ9qIRKY4OT6cJnp9rnJcqE65/oU6SBFj42lSySjSts=";
+  version = "0.11.10+166-3a9ab1d7-SNAPSHOT";
+  outputHash = "sha256-kka+FIxxIw8V8kKOiEeW5pPos3RzHyiiZ7JN453b2gw=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.10+166-3a9ab1d7-SNAPSHOT`. See https://scalameta.org/metals/latests.json