### PR TITLE
Update Metals to 0.11.10+169-73c4c93f-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.10+168-f07a4fa3-SNAPSHOT";
-  outputHash = "sha256-EbSW5foWpbKEb+I4DqWTRo1pNOIgLDW8wD4mnq/h5Yo=";
+  version = "0.11.10+169-73c4c93f-SNAPSHOT";
+  outputHash = "sha256-6PkIhjQ9DmP8NuE7EQ1OzK1iTSy1H+tUtA1sTeWzuLc=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.10+169-73c4c93f-SNAPSHOT`. See https://scalameta.org/metals/latests.json