### PR TITLE
Update Metals to 0.11.10+170-baccb626-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.10+169-73c4c93f-SNAPSHOT";
-  outputHash = "sha256-6PkIhjQ9DmP8NuE7EQ1OzK1iTSy1H+tUtA1sTeWzuLc=";
+  version = "0.11.10+170-baccb626-SNAPSHOT";
+  outputHash = "sha256-HOzN6QiguH/Jh3XbrKm6PaLx3kqywAGGFTS2EID44yY=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.10+170-baccb626-SNAPSHOT`. See https://scalameta.org/metals/latests.json