### PR TITLE
Update Metals to 0.11.10+171-a11fcac3-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.10+170-baccb626-SNAPSHOT";
-  outputHash = "sha256-HOzN6QiguH/Jh3XbrKm6PaLx3kqywAGGFTS2EID44yY=";
+  version = "0.11.10+171-a11fcac3-SNAPSHOT";
+  outputHash = "sha256-Jgk00aQmpTTCeMFmkM+x+T0JjSHp0BrXWikuizdk4Ho=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.10+171-a11fcac3-SNAPSHOT`. See https://scalameta.org/metals/latests.json