### PR TITLE
Update Metals to 0.11.10+172-d10308ef-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.10+171-a11fcac3-SNAPSHOT";
-  outputHash = "sha256-Jgk00aQmpTTCeMFmkM+x+T0JjSHp0BrXWikuizdk4Ho=";
+  version = "0.11.10+172-d10308ef-SNAPSHOT";
+  outputHash = "sha256-n9M2mgbqHYdJD+dKAiM3yd8tKuxG1AcTmzEqfy73XLc=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.10+172-d10308ef-SNAPSHOT`. See https://scalameta.org/metals/latests.json