### PR TITLE
Update Metals to 0.11.11+2-d4034d18-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.10+176-11dfd63d-SNAPSHOT";
-  outputHash = "sha256-/W2763P8dk0Cld+bEQWFpB9le5FZm1Rv55EMxFurqJQ=";
+  version = "0.11.11+2-d4034d18-SNAPSHOT";
+  outputHash = "sha256-mU2xmpuTJp7Oy0LonmEEmbUJvjw+xR2+1hHeBZGm0V4=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.11+2-d4034d18-SNAPSHOT`. See https://scalameta.org/metals/latests.json