### PR TITLE
Update Metals to 0.11.11+3-81dab9c6-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.11+2-d4034d18-SNAPSHOT";
-  outputHash = "sha256-mU2xmpuTJp7Oy0LonmEEmbUJvjw+xR2+1hHeBZGm0V4=";
+  version = "0.11.11+3-81dab9c6-SNAPSHOT";
+  outputHash = "sha256-stYRP3Eh6p3PavYbA1Z1ugrFaEuOzGYUbn+StMf9KW4=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.11+3-81dab9c6-SNAPSHOT`. See https://scalameta.org/metals/latests.json