### PR TITLE
Update Metals to 0.11.11+6-13be623f-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.11+3-81dab9c6-SNAPSHOT";
-  outputHash = "sha256-stYRP3Eh6p3PavYbA1Z1ugrFaEuOzGYUbn+StMf9KW4=";
+  version = "0.11.11+6-13be623f-SNAPSHOT";
+  outputHash = "sha256-kc/cmISgDGlksq0U2Ufe6appb09Dc7HSESr/jxVE8hE=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.11+6-13be623f-SNAPSHOT`. See https://scalameta.org/metals/latests.json