### PR TITLE
Update Metals to 0.11.11+9-000a0137-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.11+6-13be623f-SNAPSHOT";
-  outputHash = "sha256-kc/cmISgDGlksq0U2Ufe6appb09Dc7HSESr/jxVE8hE=";
+  version = "0.11.11+9-000a0137-SNAPSHOT";
+  outputHash = "sha256-fL28khIwJlK8fgedLAGofWUoTtaw4mfe2eQraNN7Cyk=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.11+9-000a0137-SNAPSHOT`. See https://scalameta.org/metals/latests.json