### PR TITLE
Update Metals to 0.11.11+13-a368d7ca-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.11+9-000a0137-SNAPSHOT";
-  outputHash = "sha256-fL28khIwJlK8fgedLAGofWUoTtaw4mfe2eQraNN7Cyk=";
+  version = "0.11.11+13-a368d7ca-SNAPSHOT";
+  outputHash = "sha256-5LzKSNg4AyjIbP85eCedxjMoJuM1bCnyhTEEdy9kg08=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.11+13-a368d7ca-SNAPSHOT`. See https://scalameta.org/metals/latests.json