### PR TITLE
Update Metals to 0.11.11+16-01e2a563-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.11+13-a368d7ca-SNAPSHOT";
-  outputHash = "sha256-5LzKSNg4AyjIbP85eCedxjMoJuM1bCnyhTEEdy9kg08=";
+  version = "0.11.11+16-01e2a563-SNAPSHOT";
+  outputHash = "sha256-vFPWDDZ5tspRAgTLrvjYv38Vp50fPTVV2KzL4o8uY5E=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.11+16-01e2a563-SNAPSHOT`. See https://scalameta.org/metals/latests.json