### PR TITLE
Update Metals to 0.11.11+17-1eb7b4e8-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.11+16-01e2a563-SNAPSHOT";
-  outputHash = "sha256-vFPWDDZ5tspRAgTLrvjYv38Vp50fPTVV2KzL4o8uY5E=";
+  version = "0.11.11+17-1eb7b4e8-SNAPSHOT";
+  outputHash = "sha256-cSOLy+xK7Ggt6ikrDd+GAqB3E5kjaSjlxtxP5eCzktc=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.11+17-1eb7b4e8-SNAPSHOT`. See https://scalameta.org/metals/latests.json