### PR TITLE
Update Metals to 0.11.11+23-88713cd0-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.11+17-1eb7b4e8-SNAPSHOT";
-  outputHash = "sha256-cSOLy+xK7Ggt6ikrDd+GAqB3E5kjaSjlxtxP5eCzktc=";
+  version = "0.11.11+23-88713cd0-SNAPSHOT";
+  outputHash = "sha256-maZWk9g3T7+apeZbH+KeuUB1Lk953N+8Fs+7QFK5zKM=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.11+23-88713cd0-SNAPSHOT`. See https://scalameta.org/metals/latests.json