### PR TITLE
Update Metals to 0.11.11+27-c568e2d6-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.11+23-88713cd0-SNAPSHOT";
-  outputHash = "sha256-maZWk9g3T7+apeZbH+KeuUB1Lk953N+8Fs+7QFK5zKM=";
+  version = "0.11.11+27-c568e2d6-SNAPSHOT";
+  outputHash = "sha256-EAvv0KfV18s+vsZQUvNPZhrcsFK699cRpISMbghQRy4=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.11+27-c568e2d6-SNAPSHOT`. See https://scalameta.org/metals/latests.json