### PR TITLE
Update Metals to 0.11.11+28-b33ed448-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.11+27-c568e2d6-SNAPSHOT";
-  outputHash = "sha256-EAvv0KfV18s+vsZQUvNPZhrcsFK699cRpISMbghQRy4=";
+  version = "0.11.11+28-b33ed448-SNAPSHOT";
+  outputHash = "sha256-7GGZBy+bjBdNzRTvmQDi7friTTDQRRoe0Gq2U2zm0w4=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.11+28-b33ed448-SNAPSHOT`. See https://scalameta.org/metals/latests.json