### PR TITLE
Update Metals to 0.11.11+41-1c11dfdf-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.11+37-da9f92bb-SNAPSHOT";
-  outputHash = "sha256-rdWQ6lPkLBz24Wtkcak3aH57A1fN7Bx7s5KCYHiUQI0=";
+  version = "0.11.11+41-1c11dfdf-SNAPSHOT";
+  outputHash = "sha256-i9Y6ebyacnkBl1mSpAfg3lyJOwt1UXEOJpO7fTbE/NM=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.11+41-1c11dfdf-SNAPSHOT`. See https://scalameta.org/metals/latests.json