### PR TITLE
Update Metals to 0.11.11+42-704ae2af-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.11+41-1c11dfdf-SNAPSHOT";
-  outputHash = "sha256-i9Y6ebyacnkBl1mSpAfg3lyJOwt1UXEOJpO7fTbE/NM=";
+  version = "0.11.11+42-704ae2af-SNAPSHOT";
+  outputHash = "sha256-hOlfkBKUBMggqaQD82XZPLWjmu/rgg0F9nQd/XgsWVI=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.11+42-704ae2af-SNAPSHOT`. See https://scalameta.org/metals/latests.json