### PR TITLE
Update Metals to 0.11.11+44-1a356541-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.11+42-704ae2af-SNAPSHOT";
-  outputHash = "sha256-hOlfkBKUBMggqaQD82XZPLWjmu/rgg0F9nQd/XgsWVI=";
+  version = "0.11.11+44-1a356541-SNAPSHOT";
+  outputHash = "sha256-TKyCd+qWOj162zVJS333ObajUIx0OmXD3FwoHRipCn8=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.11+44-1a356541-SNAPSHOT`. See https://scalameta.org/metals/latests.json