### PR TITLE
Update Metals to 0.11.11+47-8215560b-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.11+44-1a356541-SNAPSHOT";
-  outputHash = "sha256-TKyCd+qWOj162zVJS333ObajUIx0OmXD3FwoHRipCn8=";
+  version = "0.11.11+47-8215560b-SNAPSHOT";
+  outputHash = "sha256-tO6MsFmVQ51KJPEGao0ettHe8tdpSf8VkFqGauzM/Yc=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.11+47-8215560b-SNAPSHOT`. See https://scalameta.org/metals/latests.json