### PR TITLE
dunst: revert to v1.9.0

### DIFF
--- a/home/services/dunst/default.nix
+++ b/home/services/dunst/default.nix
@@ -1,11 +1,24 @@
-{ config, pkgs, ... }:
+{ pkgs, ... }:
 
 let
   colors = import ../../themes/colors.nix;
+
+  # Version 1.9.1 has a serious issue: https://github.com/dunst-project/dunst/issues/1102
+  dunst190 = pkgs.dunst.overrideAttrs (old: rec {
+    version = "1.9.0";
+
+    src = pkgs.fetchFromGitHub {
+      owner = "dunst-project";
+      repo = "dunst";
+      rev = "v${version}";
+      sha256 = "sha256-fRPhu+kpwLPvdzIpXSjXFzQTfv4xewOMv/1ZqLJw3dk=";
+    };
+  });
 in
 {
   services.dunst = {
     enable = true;
+    package = dunst190;
     iconTheme = {
       name = "BeautyLine";
       package = pkgs.beauty-line-icon-theme;

--- a/home/services/dunst/default.nix
+++ b/home/services/dunst/default.nix
@@ -13,6 +13,11 @@ let
       rev = "v${version}";
       sha256 = "sha256-fRPhu+kpwLPvdzIpXSjXFzQTfv4xewOMv/1ZqLJw3dk=";
     };
+
+    postInstall = ''
+      wrapProgram $out/bin/dunst \
+        --set GDK_PIXBUF_MODULE_FILE "$GDK_PIXBUF_MODULE_FILE"
+    '';
   });
 in
 {


### PR DESCRIPTION
CPU consumption on idle notifications is crazy, need to investigate more. Related issue: https://github.com/dunst-project/dunst/issues/1102