### PR TITLE
Update Metals to 0.11.11+66-b48e0e4e-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.11+61-32182680-SNAPSHOT";
-  outputHash = "sha256-xQvAtF4soguh8YhaSOmdo7MyXggRk3/HpuXVCN26WmU=";
+  version = "0.11.11+66-b48e0e4e-SNAPSHOT";
+  outputHash = "sha256-G0EdQRIIbsxKvbz7jZ4qCYNK3YRpMeGzdkxGtkKSXUc=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.11+66-b48e0e4e-SNAPSHOT`. See https://scalameta.org/metals/latests.json