### PR TITLE
Update Metals to 0.11.11+81-d38973c0-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.11+66-b48e0e4e-SNAPSHOT";
-  outputHash = "sha256-G0EdQRIIbsxKvbz7jZ4qCYNK3YRpMeGzdkxGtkKSXUc=";
+  version = "0.11.11+81-d38973c0-SNAPSHOT";
+  outputHash = "sha256-RUFgIVH62432s4oYayVCUxJ8Vl5NbVpFfgCCvxAHWX4=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.11+81-d38973c0-SNAPSHOT`. See https://scalameta.org/metals/latests.json