### PR TITLE
Update Metals to 0.11.12+22-6bacf42d-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.12+4-7c602e40-SNAPSHOT";
-  outputHash = "sha256-D5+KE5t1DIKbehbKv4V17laKfz9YznCjDMdA7JLSsR0=";
+  version = "0.11.12+22-6bacf42d-SNAPSHOT";
+  outputHash = "sha256-8wRbeqHW55PWLztOZKd/ye9YD/bU4rJ4v1lpKKpULIw=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.12+22-6bacf42d-SNAPSHOT`. See https://scalameta.org/metals/latests.json