### PR TITLE
Update Metals to 0.11.12+32-09988e82-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.12+22-6bacf42d-SNAPSHOT";
-  outputHash = "sha256-8wRbeqHW55PWLztOZKd/ye9YD/bU4rJ4v1lpKKpULIw=";
+  version = "0.11.12+32-09988e82-SNAPSHOT";
+  outputHash = "sha256-388dgzVRi+jwce8swYC7ncozhwJcv3Qr1XzFwBF12Es=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.12+32-09988e82-SNAPSHOT`. See https://scalameta.org/metals/latests.json