### PR TITLE
Update Metals to 0.11.12+61-88c5e82e-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.12+39-3d317418-SNAPSHOT";
-  outputHash = "sha256-oVtuSW6q7YJH2W4FWIjxXXxZImf7KKbMFdj3yvPHKZQ=";
+  version = "0.11.12+61-88c5e82e-SNAPSHOT";
+  outputHash = "sha256-XicGnLutV/rtfUnFL3RCymZZ0br679nzt+/VCPXHSGg=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.12+61-88c5e82e-SNAPSHOT`. See https://scalameta.org/metals/latests.json