### PR TITLE
Update Metals to 0.11.12+77-cce28f19-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.12+61-88c5e82e-SNAPSHOT";
-  outputHash = "sha256-XicGnLutV/rtfUnFL3RCymZZ0br679nzt+/VCPXHSGg=";
+  version = "0.11.12+77-cce28f19-SNAPSHOT";
+  outputHash = "sha256-oOnjo5C/Tc4Rnmece2dbKA+V+rjwuo7joSB+l5zrfyI=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.12+77-cce28f19-SNAPSHOT`. See https://scalameta.org/metals/latests.json