### PR TITLE
Update Metals to 0.11.12+97-f10f3269-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.12+77-cce28f19-SNAPSHOT";
-  outputHash = "sha256-oOnjo5C/Tc4Rnmece2dbKA+V+rjwuo7joSB+l5zrfyI=";
+  version = "0.11.12+97-f10f3269-SNAPSHOT";
+  outputHash = "sha256-XVgICxbeiJH+yCg6bwSYv/2mx2jfMgvu03x5OPbQtBY=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.12+97-f10f3269-SNAPSHOT`. See https://scalameta.org/metals/latests.json