### PR TITLE
Update Metals to 0.11.12+123-68e76634-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.12+105-8283260d-SNAPSHOT";
-  outputHash = "sha256-TJKC1X+6/1aPhnfB5VuPMjGsmoTDEft9cv3y6++4kHA=";
+  version = "0.11.12+123-68e76634-SNAPSHOT";
+  outputHash = "sha256-ltAWgmetz0Y29jc1ZQcaXW/PtWHEYNIj55ZSLxb85JQ=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.12+123-68e76634-SNAPSHOT`. See https://scalameta.org/metals/latests.json