### PR TITLE
Update Metals to 0.11.12+139-bc1e7dad-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.12+123-68e76634-SNAPSHOT";
-  outputHash = "sha256-ltAWgmetz0Y29jc1ZQcaXW/PtWHEYNIj55ZSLxb85JQ=";
+  version = "0.11.12+139-bc1e7dad-SNAPSHOT";
+  outputHash = "sha256-pyzltlfQjvqbUl/fryM/fXWwD0RUg0ljSaqvw/QVLCA=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.12+139-bc1e7dad-SNAPSHOT`. See https://scalameta.org/metals/latests.json