### PR TITLE
Update Metals to 0.11.12+173-cace7e1a-SNAPSHOT

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "0.11.12+160-84f04454-SNAPSHOT";
-  outputHash = "sha256-FoQNht+hl+uBCBAqAwh/XGOzPSlalk7qd1RFdj0NDbQ=";
+  version = "0.11.12+173-cace7e1a-SNAPSHOT";
+  outputHash = "sha256-VwUKJgpIue0Cx7jEWzMuWGRB9fXh6R9b75JMMy7vajE=";
 }


### PR DESCRIPTION
Update Metals to version `0.11.12+173-cace7e1a-SNAPSHOT`. See https://scalameta.org/metals/latests.json