### PR TITLE
Update Metals to 1.2.0

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "1.2.0+13-615add64-SNAPSHOT";
-  outputHash = "sha256-9ctRngrQfRQgfHTfxkT70pLm5FYs719rs2/wGjt2Io8=";
+  version = "1.2.0";
+  outputHash = "sha256-nikQ/GFRWmYYzboc9TWIi9gd5kwgCxOLhvIEQWusFik=";
 }


### PR DESCRIPTION
Update Metals to version `1.2.0`. See https://scalameta.org/metals/latests.json