### PR TITLE
add flake-schemas support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -317,6 +317,22 @@
         "type": "github"
       }
     },
+    "flake-compat_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
@@ -376,6 +392,21 @@
       "original": {
         "owner": "hercules-ci",
         "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-schemas": {
+      "locked": {
+        "lastModified": 1712496150,
+        "narHash": "sha256-P6FsavsSU3UP1VrFOTQk2VwXGkRO33prM3rtcdVkz6A=",
+        "owner": "gvolpe",
+        "repo": "flake-schemas",
+        "rev": "7d762079449d0ca63e92b0128c885021168c0c79",
+        "type": "github"
+      },
+      "original": {
+        "owner": "gvolpe",
+        "repo": "flake-schemas",
         "type": "github"
       }
     },
@@ -652,6 +683,22 @@
         "type": "github"
       }
     },
+    "libgit2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1697646580,
+        "narHash": "sha256-oX4Z3S9WtJlwvj0uH9HlYcWv+x1hqp8mhXl7HsLu2f0=",
+        "owner": "libgit2",
+        "repo": "libgit2",
+        "rev": "45fd9ed7ae1a9b74b957ef4f337bc3c8b3df01b5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "libgit2",
+        "repo": "libgit2",
+        "type": "github"
+      }
+    },
     "lsp-signature": {
       "flake": false,
       "locked": {
@@ -905,6 +952,31 @@
         "type": "github"
       }
     },
+    "nix-schema": {
+      "inputs": {
+        "flake-compat": "flake-compat_4",
+        "flake-schemas": [
+          "flake-schemas"
+        ],
+        "libgit2": "libgit2",
+        "nixpkgs": "nixpkgs_2",
+        "nixpkgs-regression": "nixpkgs-regression"
+      },
+      "locked": {
+        "lastModified": 1710167931,
+        "narHash": "sha256-MFW7NoTvbT2ckIPJQTHhMnRn1s3Ay+aAUVkL1GJPsuY=",
+        "owner": "DeterminateSystems",
+        "repo": "nix-src",
+        "rev": "d76e5fb297eec5163dacf1346b2fc07562526386",
+        "type": "github"
+      },
+      "original": {
+        "owner": "DeterminateSystems",
+        "ref": "flake-schemas",
+        "repo": "nix-src",
+        "type": "github"
+      }
+    },
     "nixd": {
       "inputs": {
         "flake-parts": "flake-parts_3",
@@ -958,7 +1030,39 @@
         "type": "github"
       }
     },
+    "nixpkgs-regression": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1709083642,
+        "narHash": "sha256-7kkJQd4rZ+vFrzWu8sTRtta5D1kBG0LSRYAfhtmMlSo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b550fe4b4776908ac2a861124307045f8e717c8e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1709961763,
         "narHash": "sha256-6H95HGJHhEZtyYA3rIQpvamMKAGoa8Yh2rFV29QnuGw=",
@@ -1456,10 +1560,12 @@
         "cowsay": "cowsay",
         "fish-bobthefish-theme": "fish-bobthefish-theme",
         "fish-keytool-completions": "fish-keytool-completions",
+        "flake-schemas": "flake-schemas",
         "gh-md-toc": "gh-md-toc",
         "home-manager": "home-manager",
         "neovim-flake": "neovim-flake",
-        "nixpkgs": "nixpkgs_2",
+        "nix-schema": "nix-schema",
+        "nixpkgs": "nixpkgs_3",
         "nurpkgs": "nurpkgs",
         "penguin-fox": "penguin-fox",
         "rycee-nurpkgs": "rycee-nurpkgs",

--- a/flake.nix
+++ b/flake.nix
@@ -1,8 +1,26 @@
 {
   description = "gvolpe's Home Manager & NixOS configurations";
 
+  nixConfig = {
+    extra-substituters = [
+      "https://cache.nixos.org"
+      "https://cache.garnix.io"
+    ];
+    extra-trusted-public-keys = [
+      "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+      "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
+    ];
+  };
+
   inputs = {
     nixpkgs.url = "nixpkgs/nixos-unstable";
+    flake-schemas.url = "github:gvolpe/flake-schemas";
+
+    ## nix client with schema support: see https://github.com/NixOS/nix/pull/8892
+    nix-schema = {
+      inputs.flake-schemas.follows = "flake-schemas";
+      url = "github:DeterminateSystems/nix-src/flake-schemas";
+    };
 
     rycee-nurpkgs = {
       url = gitlab:rycee/nur-expressions?dir=pkgs/firefox-addons;
@@ -78,10 +96,19 @@
       };
     in
     {
+      schemas =
+        inputs.flake-schemas.schemas //
+        import ./lib/schemas.nix { inherit (inputs) flake-schemas; };
+
       homeConfigurations = pkgs.mkHomeConfigurations { };
       nixosConfigurations = pkgs.mkNixosConfigurations { };
 
       out = { inherit pkgs overlays; };
+
+      apps.${system}."nix" = {
+        type = "app";
+        program = "${pkgs.nix-schema}/bin/nix";
+      };
 
       packages.${system} = {
         inherit (pkgs) bazecor metals metals-updater;

--- a/flake.nix
+++ b/flake.nix
@@ -107,7 +107,7 @@
 
       apps.${system}."nix" = {
         type = "app";
-        program = "${pkgs.nix-schema}/bin/nix";
+        program = "${pkgs.nix-schema}/bin/nix-schema";
       };
 
       packages.${system} = {

--- a/lib/overlays.nix
+++ b/lib/overlays.nix
@@ -69,6 +69,13 @@ let
       addons = f.nur.repos.rycee.firefox-addons;
     };
   };
+
+  schemaOverlay = f: p: {
+    nix-schema = inputs.nix-schema.packages.${system}.nix.overrideAttrs (old: {
+      doCheck = false;
+      doInstallCheck = false;
+    });
+  };
 in
 [
   cowsayOverlay
@@ -86,4 +93,5 @@ in
   (import ../home/overlays/ranger)
   buildersOverlay
   treesitterGrammarsOverlay
+  schemaOverlay
 ]

--- a/lib/overlays.nix
+++ b/lib/overlays.nix
@@ -74,6 +74,9 @@ let
     nix-schema = inputs.nix-schema.packages.${system}.nix.overrideAttrs (old: {
       doCheck = false;
       doInstallCheck = false;
+      postInstall = old.postInstall + ''
+        mv $out/bin/nix $out/bin/nix-schema
+      '';
     });
   };
 in

--- a/lib/schemas.nix
+++ b/lib/schemas.nix
@@ -1,0 +1,16 @@
+{ flake-schemas }:
+
+{
+  out = {
+    version = 1;
+    doc = ''
+      Exports custom attrsets like `pkgs` and `overlays` instances to be used externally.
+    '';
+    inventory = output:
+      flake-schemas.lib.mkChildren (builtins.mapAttrs
+        (_: _: {
+          what = "custom instance to be used by consumers of this flake";
+        })
+        output);
+  };
+}

--- a/system/configuration.nix
+++ b/system/configuration.nix
@@ -49,11 +49,11 @@ in
   # Set your time zone.
   time.timeZone = "Europe/Warsaw";
 
-  # List packages installed in system profile. To search, run:
-  # $ nix search wget
+  # List packages installed in system profile
   environment.systemPackages = with pkgs; [
     globalprotect-openconnect
     firejail
+    nix-schema
     vim
     wget
   ];

--- a/system/machine/dell-xps/default.nix
+++ b/system/machine/dell-xps/default.nix
@@ -13,7 +13,6 @@
       grub = {
         enable = true;
         device = "/dev/nvme0n1"; # or "nodev" for efi only
-        version = 2;
       };
     };
   };


### PR DESCRIPTION
Try it out as follows:

```console
nix run .#nix -- flake show
```

Or set `nix.package` to `nix-schema` in your `configuration.nix` to make it permanent.

![nix-flake-schemas](https://github.com/gvolpe/nix-config/assets/443978/747e02d6-37d7-44c2-97fb-6193578f337d)

This uses a `nix` version with schemas support: https://github.com/NixOS/nix/pull/8892