### PR TITLE
Update Metals to 1.3.5

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "1.3.4";
-  outputHash = "sha256-g3nOqqoNjZ/lURPO3NVXqmlIbFtwRgKCaz7CJXU1Ups=";
+  version = "1.3.5";
+  outputHash = "sha256-86/zeoOO5kSAwh7uQTV7nGUGQoIux1rlH5eUgvn3kvY=";
 }


### PR DESCRIPTION
Update Metals to version `1.3.5`. See https://scalameta.org/metals/latests.json