### PR TITLE
re-enable github actions

### DIFF
--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -22,11 +22,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    #if: github.action == 'Garnix CI / Evaluate flake.nix'
-    if: >-
-      github.event.state == 'error' ||
-      github.event.state == 'failure'
-
     strategy:
       fail-fast: true
       matrix:
@@ -39,11 +34,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.3.2
-
-      - name: "DEBUG"
-        run: |
-          echo "Event state: ${{ github.event.state }}"
-          echo "Event desc: ${{ github.event.description }}"
 
       - name: "Install Nix ❄️"
         uses: cachix/install-nix-action@v30

--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -22,6 +22,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    #if: github.action == 'Garnix CI / Evaluate flake.nix'
+    if: >-
+      github.event.state == 'error' ||
+      github.event.state == 'failure'
+
     strategy:
       fail-fast: true
       matrix:
@@ -34,6 +39,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.3.2
+
+      - name: "DEBUG"
+        run: |
+          echo "Event state: ${{ github.event.state }}"
+          echo "Event desc: ${{ github.event.description }}"
 
       - name: "Install Nix ❄️"
         uses: cachix/install-nix-action@v30

--- a/.github/workflows/home.yml
+++ b/.github/workflows/home.yml
@@ -1,0 +1,52 @@
+name: Home
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'GNOME.md'
+      - 'README.md'
+      - 'notes/**'
+      - '.git-crypt/**'
+      - '.gitattributes'
+      - '.gitignore'
+      - 'system/**'
+      - 'outputs/os.nix'
+      - 'switch'
+      - '.mergify.yml'
+      - 'garnix.yaml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: true
+      matrix:
+        config_name:
+          - hyprland-edp
+          - hyprland-hdmi
+          - hyprland-hdmi-mutable
+          - xmonad-edp
+          - xmonad-hdmi
+
+    steps:
+      - uses: actions/checkout@v2.3.2
+
+      - name: "Install Nix ❄️"
+        uses: cachix/install-nix-action@v30
+
+      - name: "Install Cachix ❄️"
+        uses: cachix/cachix-action@v15
+        with:
+          name: gvolpe-nixos
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
+      # Needed because cachix is also installed by Home Manager
+      - name: "Set priority flag for Cachix 🚩"
+        run: nix-env --set-flag priority 0 cachix
+
+      - name: "Build ${{ matrix.config_name }} Home Manager config 🏠"
+        run: nix build .#homeConfigurations.${{ matrix.config_name }}.activationPackage -L

--- a/.github/workflows/nixos.yml
+++ b/.github/workflows/nixos.yml
@@ -49,6 +49,6 @@ jobs:
       - name: "Set priority flag for Cachix 🚩"
         run: nix-env --set-flag priority 0 cachix
 
-      - name: "Build ${{ matrix.config_name }} Home Manager config 🏠"
+      - name: "Build ${{ matrix.config_name }} NixOS config ❄️"
         run: nix build .#nixosConfigurations.${{ matrix.hostname }}.config.system.build.toplevel -L
 

--- a/.github/workflows/nixos.yml
+++ b/.github/workflows/nixos.yml
@@ -1,0 +1,54 @@
+name: NixOS
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'home/**'
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'GNOME.md'
+      - 'README.md'
+      - 'notes/**'
+      - '.git-crypt/**'
+      - '.gitattributes'
+      - '.gitignore'
+      - 'home/**'
+      - 'outputs/hm.nix'
+      - 'switch'
+      - '.mergify.yml'
+      - 'garnix.yaml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: true
+      matrix:
+        hostname:
+          - dell-xps
+          - thinkpad-x1
+          - tongfang-amd
+          - xmod
+
+    steps:
+      - uses: actions/checkout@v2.3.2
+
+      - name: "Install Nix ❄️"
+        uses: cachix/install-nix-action@v30
+
+      - name: "Install Cachix ❄️"
+        uses: cachix/cachix-action@v15
+        with:
+          name: gvolpe-nixos
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
+      # Needed because cachix is also installed by Home Manager
+      - name: "Set priority flag for Cachix 🚩"
+        run: nix-env --set-flag priority 0 cachix
+
+      - name: "Build ${{ matrix.config_name }} Home Manager config 🏠"
+        run: nix build .#nixosConfigurations.${{ matrix.hostname }}.config.system.build.toplevel -L
+

--- a/.github/workflows/nixos.yml
+++ b/.github/workflows/nixos.yml
@@ -50,7 +50,7 @@ jobs:
         run: nix-env --set-flag priority 0 cachix
 
       - name: "Free Disk Space (Ubuntu)"
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@main
           with:
             tool-cache: true
 

--- a/.github/workflows/nixos.yml
+++ b/.github/workflows/nixos.yml
@@ -1,12 +1,8 @@
 name: NixOS
 
 on:
-  pull_request:
-    paths-ignore:
-      - 'home/**'
-  push:
-    branches:
-      - master
+  check_run:
+    types: [failure]
     paths-ignore:
       - 'GNOME.md'
       - 'README.md'
@@ -19,6 +15,25 @@ on:
       - 'switch'
       - '.mergify.yml'
       - 'garnix.yaml'
+#on:
+  #pull_request:
+    #paths-ignore:
+      #- 'home/**'
+  #push:
+    #branches:
+      #- master
+    #paths-ignore:
+      #- 'GNOME.md'
+      #- 'README.md'
+      #- 'notes/**'
+      #- '.git-crypt/**'
+      #- '.gitattributes'
+      #- '.gitignore'
+      #- 'home/**'
+      #- 'outputs/hm.nix'
+      #- 'switch'
+      #- '.mergify.yml'
+      #- 'garnix.yaml'
 
 jobs:
   build:

--- a/.github/workflows/nixos.yml
+++ b/.github/workflows/nixos.yml
@@ -24,6 +24,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    #if: github.action == 'Garnix CI / Evaluate flake.nix'
+    #if: >-
+      #github.event.state == 'error' ||
+      #github.event.state == 'failure'
+
     strategy:
       fail-fast: true
       matrix:
@@ -35,6 +40,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2.3.2
+
+      - name: "DEBUG"
+        run: |
+          echo "Event state: ${{ github.event.state }}"
+          echo "Event desc: ${{ github.event.description }}"
 
       - name: "Install Nix ❄️"
         uses: cachix/install-nix-action@v30

--- a/.github/workflows/nixos.yml
+++ b/.github/workflows/nixos.yml
@@ -49,6 +49,10 @@ jobs:
       - name: "Set priority flag for Cachix 🚩"
         run: nix-env --set-flag priority 0 cachix
 
+      - name: "Free Disk Space (Ubuntu)"
+        uses: jlumbroso/free-disk-space@v1.3.1
+          with:
+            tool-cache: true
+
       - name: "Build ${{ matrix.config_name }} NixOS config ❄️"
         run: nix build .#nixosConfigurations.${{ matrix.hostname }}.config.system.build.toplevel -L
-

--- a/.github/workflows/nixos.yml
+++ b/.github/workflows/nixos.yml
@@ -51,8 +51,8 @@ jobs:
 
       - name: "Free Disk Space (Ubuntu)"
         uses: jlumbroso/free-disk-space@main
-          with:
-            tool-cache: true
+        with:
+          tool-cache: true
 
       - name: "Build ${{ matrix.config_name }} NixOS config ❄️"
         run: nix build .#nixosConfigurations.${{ matrix.hostname }}.config.system.build.toplevel -L

--- a/.github/workflows/update-metals.yml
+++ b/.github/workflows/update-metals.yml
@@ -8,7 +8,7 @@ jobs:
   fetcher:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.2
 
       - name: "Install Nix ❄️"
         uses: cachix/install-nix-action@v18

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@ nix-config
 ==========
 
 [![ci-badge](https://img.shields.io/static/v1?label=Built%20with&message=nix&color=blue&style=flat&logo=nixos&link=https://nixos.org&labelColor=111212)](https://gvolpe.com)
-[![built with garnix](https://img.shields.io/endpoint?url=https%3A%2F%2Fgarnix.io%2Fapi%2Fbadges%2Fgvolpe%2Fnix-config%3Fbranch%3Dmaster)](https://garnix.io)
+[![Home](https://github.com/gvolpe/nix-config/actions/workflows/home.yml/badge.svg)](https://github.com/gvolpe/nix-config/actions/workflows/home.yml)
+[![NixOS](https://github.com/gvolpe/nix-config/actions/workflows/nixos.yml/badge.svg)](https://github.com/gvolpe/nix-config/actions/workflows/nixos.yml)
+[![garnix](https://img.shields.io/endpoint?url=https%3A%2F%2Fgarnix.io%2Fapi%2Fbadges%2Fgvolpe%2Fnix-config%3Fbranch%3Dmaster)](https://garnix.io)
 
 My current — and always evolving — NixOS configuration files, home-manager, neovim, etc.
 


### PR DESCRIPTION
As good as Garnix is, it's too costly at [$300 a year](https://garnix.io/pricing) for my personal use, so I'm bringing back Github Actions as a backup build for whenever the free Garnix builds quota is exhausted (like now).