### PR TITLE
ci: fix check suite id

### DIFF
--- a/.github/actions/garnix-check/action.yml
+++ b/.github/actions/garnix-check/action.yml
@@ -16,6 +16,12 @@ runs:
       id: garnix
       shell: bash
       run: |
+        curl -L \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ inputs.github_token }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/gvolpe/nix-config/commits/${{ github.sha  }}/check-runs | jq
+
         STATUS=$(curl -L \
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer ${{ inputs.github_token }}" \

--- a/.github/actions/garnix-check/action.yml
+++ b/.github/actions/garnix-check/action.yml
@@ -20,7 +20,7 @@ runs:
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer ${{ inputs.github_token }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
-          https://api.github.com/repos/gvolpe/nix-config/commits/${{ github.sha  }}/check-runs | jq
+          https://api.github.com/repos/gvolpe/nix-config/commits/${{ github.head_ref  }}/check-runs | jq
 
         STATUS=$(curl -L \
           -H "Accept: application/vnd.github+json" \

--- a/.github/actions/garnix-check/action.yml
+++ b/.github/actions/garnix-check/action.yml
@@ -21,7 +21,7 @@ runs:
           -H "Authorization: Bearer ${{ inputs.github_token }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/gvolpe/nix-config/commits/${{ github.head_ref  }}/check-runs | \
-          jq -r '.check_runs | .[] | select (.name | contains("Evaluate flake.nix")) | .check_suite.id')
+          jq -r '.check_runs | .[] | select (.name | contains("Evaluate flake.nix")) | .check_suite.id'
 
         STATUS=$(curl -L \
           -H "Accept: application/vnd.github+json" \

--- a/.github/actions/garnix-check/action.yml
+++ b/.github/actions/garnix-check/action.yml
@@ -16,17 +16,20 @@ runs:
       id: garnix
       shell: bash
       run: |
-        curl -L \
+        CHECK_SUITE_ID=$(curl -L \
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer ${{ inputs.github_token }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           https://api.github.com/repos/gvolpe/nix-config/commits/${{ github.head_ref  }}/check-runs | \
-          jq -r '.check_runs | .[] | select (.name | contains("Evaluate flake.nix")) | .check_suite.id'
+          jq -r '.check_runs | .[] | select (.name | contains("Evaluate flake.nix")) | .check_suite.id')
+
+        echo "Garnix Check Suite ID: $CHECK_SUITE_ID"
 
         STATUS=$(curl -L \
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer ${{ inputs.github_token }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
-          https://api.github.com/repos/gvolpe/nix-config/check-suites/33419075802/check-runs | \
+          https://api.github.com/repos/gvolpe/nix-config/check-suites/$CHECK_SUITE_ID/check-runs | \
           jq -r '.check_runs | .[] | select (.output.text | contains("monthly CI quota")) | select (.status == "completed") | .conclusion')
+
         echo "status=$STATUS" | tee -a "$GITHUB_OUTPUT"

--- a/.github/actions/garnix-check/action.yml
+++ b/.github/actions/garnix-check/action.yml
@@ -10,8 +10,6 @@ outputs:
 runs:
   using: "composite"
   steps:
-    # I got the check suite ID from: https://api.github.com/repos/gvolpe/nix-config/commits/REF/check-runs
-    # where REF == branch name (didn't work with the commit sha for some reason)
     - name: Garnix check status
       id: garnix
       shell: bash

--- a/.github/actions/garnix-check/action.yml
+++ b/.github/actions/garnix-check/action.yml
@@ -20,7 +20,8 @@ runs:
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer ${{ inputs.github_token }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
-          https://api.github.com/repos/gvolpe/nix-config/commits/${{ github.head_ref  }}/check-runs | jq
+          https://api.github.com/repos/gvolpe/nix-config/commits/${{ github.head_ref  }}/check-runs | \
+          jq -r '.check_runs | .[] | select (.name | contains("Evaluate flake.nix")) | .check_suite.id')
 
         STATUS=$(curl -L \
           -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
The Check Suite ID is not static as I thought, so we need to fetch it from the last commit before making that check suite request.