### PR TITLE
Update Metals to 1.6.1

### DIFF
--- a/home/programs/neovim-ide/metals.nix
+++ b/home/programs/neovim-ide/metals.nix
@@ -1,6 +1,6 @@
 { metalsBuilder }:
 
 metalsBuilder {
-  version = "1.6.0";
+  version = "1.6.1";
   outputHash = "sha256-+6u/nnaoCBEQCwhvPs1WQzMnppz7KEWWd1TlzbKYpAU=";
 }


### PR DESCRIPTION
Update Metals to version `1.6.1`. See https://scalameta.org/metals/latests.json