### PR TITLE
flakes: update all inputs on Aug 03, 2026

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -744,7 +744,7 @@
     },
     "flake-utils_8": {
       "inputs": {
-        "systems": "systems_7"
+        "systems": "systems_6"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -1584,21 +1584,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-gram": {
-      "locked": {
-        "lastModified": 1783754472,
-        "narHash": "sha256-jS1cnt9j6OkoDoHlURQEDYtJcUHOSwuYGexSvx9aDd4=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "770b9bbb84018993c8f009d437fff6c2e3077037",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "rev": "770b9bbb84018993c8f009d437fff6c2e3077037",
-        "type": "indirect"
-      }
-    },
     "nixpkgs-hyprland": {
       "locked": {
         "lastModified": 1737847078,
@@ -1626,22 +1611,6 @@
       "original": {
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixpkgs-libxml2": {
-      "locked": {
-        "lastModified": 1751274312,
-        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.11",
-        "repo": "nixpkgs",
         "type": "github"
       }
     },
@@ -1688,22 +1657,6 @@
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_11": {
-      "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
@@ -2423,7 +2376,6 @@
         "nix-index-database": "nix-index-database",
         "nix-search": "nix-search",
         "nixpkgs": "nixpkgs_8",
-        "nixpkgs-gram": "nixpkgs-gram",
         "nixpkgs-hyprland": "nixpkgs-hyprland",
         "nord-tmux": "nord-tmux",
         "nsticky-flake": "nsticky-flake",
@@ -2434,7 +2386,6 @@
         "snitch": "snitch",
         "sunix": "sunix",
         "tree-sitter-scala": "tree-sitter-scala_2",
-        "vicinae": "vicinae",
         "waycal": "waycal",
         "wooz-flake": "wooz-flake",
         "wshowkeys": "wshowkeys"
@@ -2578,25 +2529,6 @@
         "type": "github"
       }
     },
-    "soulver-cpp": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_11",
-        "nixpkgs-libxml2": "nixpkgs-libxml2"
-      },
-      "locked": {
-        "lastModified": 1783621734,
-        "narHash": "sha256-YBFO+aurlz2y2hTRN1Kl0RjX6JzHn0mYBmt4zb436Yg=",
-        "owner": "vicinaehq",
-        "repo": "soulver-cpp",
-        "rev": "00e926e2bd03118638c88981f6a67bfa107210c2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "vicinaehq",
-        "repo": "soulver-cpp",
-        "type": "github"
-      }
-    },
     "sqls-nvim": {
       "flake": false,
       "locked": {
@@ -2709,21 +2641,6 @@
       }
     },
     "systems_6": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_7": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -3015,28 +2932,6 @@
         "owner": "snowfallorg",
         "ref": "v1.0.0",
         "repo": "vhs",
-        "type": "github"
-      }
-    },
-    "vicinae": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "soulver-cpp": "soulver-cpp",
-        "systems": "systems_6"
-      },
-      "locked": {
-        "lastModified": 1785733880,
-        "narHash": "sha256-Rv4rVFSvxF7ViOQOrv+N8IEvweS5MCqUM2fnaQVIR+w=",
-        "owner": "vicinaehq",
-        "repo": "vicinae",
-        "rev": "61bd7cd5c9cdd6d8df6e6d34531beb344219ff71",
-        "type": "github"
-      },
-      "original": {
-        "owner": "vicinaehq",
-        "repo": "vicinae",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -216,18 +216,35 @@
         "type": "github"
       }
     },
+    "dank-qml-common": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1784074596,
+        "narHash": "sha256-/rCqHgC39mHvBDxb/dZLWCQ3W4ev94y3/1KtCRSPDp8=",
+        "owner": "AvengeMedia",
+        "repo": "dank-qml-common",
+        "rev": "b50afcf549f7e9c8f07c85b7f3fbba867701650d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "AvengeMedia",
+        "repo": "dank-qml-common",
+        "type": "github"
+      }
+    },
     "dankcalendar": {
       "inputs": {
+        "dank-qml-common": "dank-qml-common",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1783046648,
-        "narHash": "sha256-SNkBGEkksCPwU049QFBEJRR4Z2siGc08IYanQnQNees=",
+        "lastModified": 1785617619,
+        "narHash": "sha256-MDUHB9hKjP6nse+zTqgbcb1/pBgjV/FJ1j/4hkChu+M=",
         "owner": "AvengeMedia",
         "repo": "dankcalendar",
-        "rev": "65f0fcdb5639cb0a02b4322cfee9a0d87b7f43a0",
+        "rev": "01a431722fe2afbfc6e99698a7ba9894ca834a5e",
         "type": "github"
       },
       "original": {
@@ -245,12 +262,12 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1784591579,
-        "narHash": "sha256-Ri/OBH1gg42wgC02OuFKBZu68niiRkHyBphK0pxJLfQ=",
-        "rev": "979cc556a2d619079b9f8618226e679d58f0901a",
-        "revCount": 26280,
+        "lastModified": 1785428605,
+        "narHash": "sha256-wfaiSRLM1wDb4MV+NEzbyheK9Y03/oe56NR2I84UF7E=",
+        "rev": "0ff46631f69584c9f76792cae595ea253bd482c3",
+        "revCount": 26288,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nix-src/3.21.8/019f821d-c2c8-79a1-824b-8fa3b0dcdc51/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nix-src/3.21.9/019fb409-4d6e-7243-8a88-23ceee2520e9/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -308,11 +325,11 @@
     },
     "dots": {
       "locked": {
-        "lastModified": 1785740384,
-        "narHash": "sha256-r29kUNo40mNV0mJMm4EBPoZU60x8Ug9QQukmQg3DXK8=",
+        "lastModified": 1785741684,
+        "narHash": "sha256-euN2ytxylM0kd2V0U8TyBE8o7yS9zG9a/mtgz2fFuTM=",
         "owner": "gvolpe",
         "repo": "dots",
-        "rev": "e50907622f50c404522fd12d95776f0376a952ab",
+        "rev": "639dc3bac838f390e9518001a41bafd1c3618bf5",
         "type": "github"
       },
       "original": {
@@ -898,11 +915,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783134515,
-        "narHash": "sha256-qMoZazubXlXUD9k/syJ/aiWC4X4g73mwVmZ7Z4+rdpM=",
+        "lastModified": 1785531816,
+        "narHash": "sha256-vkMnV0JIyw+g/NmcfoajlGaAO+9a0ezia+FZohQJrik=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b885baad531fa3d3beae2ba9a0712d22974d8016",
+        "rev": "bf9ce9fec78f95f374e8dd3b503863a3ec128ebe",
         "type": "github"
       },
       "original": {
@@ -1098,11 +1115,11 @@
     "metals-zed": {
       "flake": false,
       "locked": {
-        "lastModified": 1784645206,
-        "narHash": "sha256-z8qeE5UxeMBxnB6GQp4z0qsFYB25qzRWhTYGr/ZO00s=",
+        "lastModified": 1785249279,
+        "narHash": "sha256-RfsYEKkWZ9aRMbA2SCq249p9J9dyJHY/+5nxOATVjfA=",
         "owner": "scalameta",
         "repo": "metals-zed",
-        "rev": "c88759e7e5e49d1ee7bba1284dfe2fb3170c979b",
+        "rev": "689e93f038b887fb4665dcbff141e3d7d5c66155",
         "type": "github"
       },
       "original": {
@@ -1383,11 +1400,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1783123561,
-        "narHash": "sha256-A4XJC5qR19bBJ3KO3oE1cK4e98bPrO5QYcSNPVZuUas=",
+        "lastModified": 1785705919,
+        "narHash": "sha256-fkLVrf2tZ/822v+kF2NgXxQD5ugMNTgGlUd7Y1kHEHg=",
         "owner": "sodiboo",
         "repo": "niri-flake",
-        "rev": "62b5feade147800f4e49503ae6fb643892689d65",
+        "rev": "50e136c5452ae98638d066454391c7ba7e16410a",
         "type": "github"
       },
       "original": {
@@ -1399,11 +1416,11 @@
     "niri-main": {
       "flake": false,
       "locked": {
-        "lastModified": 1781781064,
-        "narHash": "sha256-Ii/koEm/sRyg65qbAQWqEgboSEIhdH0EL4KglAc14p0=",
+        "lastModified": 1785701241,
+        "narHash": "sha256-ircVOzPWRircI39ac/tqJajr5OoJxEVrDlBb05TULEk=",
         "owner": "niri-wm",
         "repo": "niri",
-        "rev": "49fc6117fd6c043adaa2ead316b82db5ed735d36",
+        "rev": "feb3e43f1475e0865bb89cbd1e898b34d1d2ccf6",
         "type": "github"
       },
       "original": {
@@ -1482,11 +1499,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783023993,
-        "narHash": "sha256-gaOvvY/lL1eWoSmSRO17pWry8R49AuPMrF4nzu47K5o=",
+        "lastModified": 1785650611,
+        "narHash": "sha256-q4kR7g+pCcz6NASvoVPYu+CWWUurX03wogtBqGmR4h0=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "f8ed6cdcb1fd28a6ab7b61f4467a4f67fe2d9074",
+        "rev": "dbc756c9d7287de19b3e0e38c928c47510d42c3e",
         "type": "github"
       },
       "original": {
@@ -1612,6 +1629,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-libxml2": {
+      "locked": {
+        "lastModified": 1751274312,
+        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-regression": {
       "locked": {
         "lastModified": 1643052045,
@@ -1646,15 +1679,31 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1782959384,
-        "narHash": "sha256-xnJJk+ct+D2+wdRxj1wk36w5zV9RVESwRqcklPdt3fM=",
+        "lastModified": 1785571196,
+        "narHash": "sha256-KoTsyMQqnXQZq8deCEnu4QkyldkwH/bpMMhUcfMdGIw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "65179426c83bb3f6bc14898b42ea1c6f01d374b0",
+        "rev": "148bab9c1c3c53136ecb44a6ea356a0ed5b39b06",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_11": {
+      "locked": {
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
@@ -1755,10 +1804,10 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1782959384,
-        "narHash": "sha256-xnJJk+ct+D2+wdRxj1wk36w5zV9RVESwRqcklPdt3fM=",
+        "lastModified": 1785571196,
+        "narHash": "sha256-KoTsyMQqnXQZq8deCEnu4QkyldkwH/bpMMhUcfMdGIw=",
         "ref": "nixos-unstable",
-        "rev": "65179426c83bb3f6bc14898b42ea1c6f01d374b0",
+        "rev": "148bab9c1c3c53136ecb44a6ea356a0ed5b39b06",
         "shallow": true,
         "type": "git",
         "url": "https://github.com/NixOS/nixpkgs"
@@ -1842,11 +1891,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1782863545,
-        "narHash": "sha256-loZHSHtkgH4dcR+6M5P7APFLZOhONlkjlSGcBi+oFPM=",
+        "lastModified": 1785286127,
+        "narHash": "sha256-DjJU3ucxnLEjR8N8WM6daQN3fxLQP9v03EK3ASaLnCg=",
         "owner": "lonerOrz",
         "repo": "nsticky",
-        "rev": "cae90c7a2563f36efa7c20265b5f5a3d5fb07494",
+        "rev": "4f6e57f64e7038f7fa4951854b752dfb7434a18c",
         "type": "github"
       },
       "original": {
@@ -1877,11 +1926,11 @@
         "nixpkgs": "nixpkgs_10"
       },
       "locked": {
-        "lastModified": 1783163979,
-        "narHash": "sha256-Rlln82WM2FnQu3QdHinepHk0a5YNEhYN/Up1m1MyVq8=",
+        "lastModified": 1785742658,
+        "narHash": "sha256-QZvKM36xoVPdE6crmyDUT0v6v0DCw75zfcxK/aFQPrg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "01916709fe88203453479189a84c323d0a25060b",
+        "rev": "fe4ea4be6e6cc044a55c48251deb9452129a6d72",
         "type": "github"
       },
       "original": {
@@ -2268,11 +2317,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1784647469,
-        "narHash": "sha256-348YvOpYCiPDkstNg8g+jB3JIvqiMM7wXTS1EIqlWeI=",
+        "lastModified": 1785459394,
+        "narHash": "sha256-6KHAEEhcylONrG9GKFsZzyNGJqj82IuCq3eefopTsd0=",
         "owner": "swarsel",
         "repo": "pedantix",
-        "rev": "8d762c8a9275feb215ce1268970f99779d3cdb04",
+        "rev": "91464672e038a77c8dc64c68d26128859ca10870",
         "type": "github"
       },
       "original": {
@@ -2431,11 +2480,11 @@
       },
       "locked": {
         "dir": "pkgs/firefox-addons",
-        "lastModified": 1783137763,
-        "narHash": "sha256-MedB3zphmF3ie1tQDYLJbpIdDByYD9Sf9gkjC7et+h4=",
+        "lastModified": 1785729742,
+        "narHash": "sha256-PBavY37OTsIM7VJMUYPv2Rz/gSpbtJGxAGl9iXCaMU4=",
         "owner": "rycee",
         "repo": "nur-expressions",
-        "rev": "d84e72970b14f90170b1b7fb09adc59cbf40eb3b",
+        "rev": "1529ecae5978cd2ac18a8edbf27967350bf4b80e",
         "type": "gitlab"
       },
       "original": {
@@ -2526,6 +2575,25 @@
       "original": {
         "owner": "snowfallorg",
         "repo": "lib",
+        "type": "github"
+      }
+    },
+    "soulver-cpp": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_11",
+        "nixpkgs-libxml2": "nixpkgs-libxml2"
+      },
+      "locked": {
+        "lastModified": 1783621734,
+        "narHash": "sha256-YBFO+aurlz2y2hTRN1Kl0RjX6JzHn0mYBmt4zb436Yg=",
+        "owner": "vicinaehq",
+        "repo": "soulver-cpp",
+        "rev": "00e926e2bd03118638c88981f6a67bfa107210c2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vicinaehq",
+        "repo": "soulver-cpp",
         "type": "github"
       }
     },
@@ -2842,11 +2910,11 @@
         "nixpkgs": "nixpkgs_9"
       },
       "locked": {
-        "lastModified": 1780220602,
-        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "lastModified": 1784369104,
+        "narHash": "sha256-47cxbcZODibHv3rELFQ9vZly0vUNkND/atn/U7HLeb0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "rev": "df3c0640565d04a0261253cdd89fce78ec50168a",
         "type": "github"
       },
       "original": {
@@ -2955,14 +3023,15 @@
         "nixpkgs": [
           "nixpkgs"
         ],
+        "soulver-cpp": "soulver-cpp",
         "systems": "systems_6"
       },
       "locked": {
-        "lastModified": 1783128344,
-        "narHash": "sha256-mwFrNlxHbhZ0aVELj0gpSE4W2ViU1YxGg6Jof5JSq24=",
+        "lastModified": 1785733880,
+        "narHash": "sha256-Rv4rVFSvxF7ViOQOrv+N8IEvweS5MCqUM2fnaQVIR+w=",
         "owner": "vicinaehq",
         "repo": "vicinae",
-        "rev": "8a7ce00331b9505b26b84a7d426f67a6b127836f",
+        "rev": "61bd7cd5c9cdd6d8df6e6d34531beb344219ff71",
         "type": "github"
       },
       "original": {
@@ -3075,11 +3144,11 @@
     "wshowkeys": {
       "flake": false,
       "locked": {
-        "lastModified": 1757812704,
-        "narHash": "sha256-N8V6CkCmTlw0rWmDXiKI1Z4YS7T7fWCr9aPRk5OpGHs=",
+        "lastModified": 1785224811,
+        "narHash": "sha256-8upkB3179A8wP5Hph0EanE0VuIxe7VsmsqzcRaOq5y0=",
         "owner": "DreamMaoMao",
         "repo": "wshowkeys",
-        "rev": "184f55dbc5320c34a56d02353410ad35a0f3e090",
+        "rev": "35d70762ab9af4ea301853e79b3b925d5fe9e920",
         "type": "github"
       },
       "original": {
@@ -3108,11 +3177,11 @@
     "xwayland-satellite-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1781226823,
-        "narHash": "sha256-28696iIw8uE0ZUyFTtzhEM8xMh85clCYypMxkvUi+sc=",
+        "lastModified": 1784679892,
+        "narHash": "sha256-Mb7jpqnrcYCfNSItIkkHpuR3YxWFxPuIBfcwNKlRBkk=",
         "owner": "Supreeeme",
         "repo": "xwayland-satellite",
-        "rev": "8575d0ef55d70f9b4c46b6bffb3accf912217e1e",
+        "rev": "8d135d3b2854b30fd01ea6cd6c27e523dd50a839",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -125,11 +125,6 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    vicinae = {
-      url = github:vicinaehq/vicinae;
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-
     waycal = {
       url = github:forrestknight/waycal;
       flake = false;

--- a/flake.nix
+++ b/flake.nix
@@ -174,9 +174,6 @@
     };
 
     # Gram editor
-    # TODO: remove on next nixpkgs upgrade
-    nixpkgs-gram.url = "nixpkgs/770b9bbb84018993c8f009d437fff6c2e3077037"; # v3.0.1
-
     gram-extensions = {
       url = "git+https://tangled.org/niklaskorz.eu/nix-gram-extensions";
       # codeberg is very slow and unreliable

--- a/home/modules/software.nix
+++ b/home/modules/software.nix
@@ -28,7 +28,6 @@ in
       gimp # gnu image manipulation program
       hyperfine # command-line benchmarking tool
       insomnia # rest client with graphql support
-      jmtpfs # mount mtp devices
       killall # kill processes by name
       libreoffice # office suite
       lnav # log file navigator on the terminal

--- a/home/services/polybar/scripts/mpris.nix
+++ b/home/services/polybar/scripts/mpris.nix
@@ -2,7 +2,6 @@
 
 let
   pctl = "${pkgs.playerctl}/bin/playerctl";
-  zsc = "${pkgs.zscroll}/bin/zscroll";
 
   format = ''
     {{ artist }} - {{ title }} [{{ duration(mpris:length) }}]
@@ -27,8 +26,9 @@ let
   '';
 in
 # Credits to https://github.com/PrayagS/polybar-spotify for the scrolling idea
+# needs the zscroll which has been removed from nixpkgs
 pkgs.writeShellScriptBin "mpris" ''
-  ${zsc} -l 40 \
+  zscroll -l 40 \
          --delay 0.3 \
          --scroll-padding "  " \
          --match-command "${status}/bin/spotify_status" \

--- a/home/services/vicinae/default.nix
+++ b/home/services/vicinae/default.nix
@@ -1,16 +1,18 @@
-{ pkgs, config, ... }:
+{ config, ... }:
 
 let
-  gifSearch = pkgs.mkRayCastExtension {
+  inherit (config.lib.vicinae) mkRayCastExtension;
+
+  gifSearch = mkRayCastExtension {
     name = "gif-search";
-    sha256 = "sha256-/59ZaKe6gUkemauakgSvwkb76kN3aciKHgAh2yYk6jI=";
     rev = "365c9557780eb21293979aed3de9e06c05fab51f";
+    sha256 = "sha256-/59ZaKe6gUkemauakgSvwkb76kN3aciKHgAh2yYk6jI=";
   };
 
-  jwtDecoder = pkgs.mkRayCastExtension {
+  jwtDecoder = mkRayCastExtension {
     name = "jwt-decoder";
-    sha256 = "sha256-/dHuBYGcN/uJWKHdjCLByP9GCk+UoxefuWhT/RPWWzA=";
     rev = "365c9557780eb21293979aed3de9e06c05fab51f";
+    sha256 = "sha256-/dHuBYGcN/uJWKHdjCLByP9GCk+UoxefuWhT/RPWWzA=";
   };
 in
 {
@@ -18,12 +20,10 @@ in
     enable = true;
     extensions = [ gifSearch jwtDecoder ];
     systemd = {
-      enable = true;
       autoStart = true;
-      environment = {
-        USE_LAYER_SHELL = 1;
-      };
+      enable = true;
     };
+    useLayerShell = true;
   };
 
   xdg.configFile."vicinae/settings.json".source =

--- a/lib/overlays.nix
+++ b/lib/overlays.nix
@@ -67,9 +67,6 @@ let
 
     wooz = inputs.wooz-flake.packages.${system}.default;
 
-    # gram v3.0.1
-    gram = inputs.nixpkgs-gram.legacyPackages.${system}.gram;
-
     gram-ext = {
       inherit (inputs.gram-extensions.packages.${system})
         buildGramExtension buildGramRustExtension linkGramExtensions

--- a/lib/overlays.nix
+++ b/lib/overlays.nix
@@ -93,7 +93,6 @@ in
   inputs.nix-index.overlays.default
   inputs.nurpkgs.overlays.default
   inputs.niri-flake.overlays.niri
-  inputs.vicinae.overlays.default
   metalsOverlay
   (import ../home/overlays/bazecor)
   (import ../home/overlays/determinate-nix)

--- a/outputs/hm.nix
+++ b/outputs/hm.nix
@@ -37,7 +37,6 @@ let
     mods = [
       inputs.dankcalendar.homeModules.default
       inputs.sunix.homeModules.default
-      inputs.vicinae.homeManagerModules.default
       ../home/wm/niri
     ];
   };

--- a/system/host/dell-xps/hardware-configuration.nix
+++ b/system/host/dell-xps/hardware-configuration.nix
@@ -1,7 +1,7 @@
 { ... }:
 
 {
-  # TODO: these are dummy file systems, get the proper one
+  # these are dummy file systems, get the proper one
   fileSystems."/boot" =
     {
       device = "/dev/disk/by-uuid/7BB3-09C5";


### PR DESCRIPTION
# Flakes update ❄️ 

The following reports have been produced by [SUNix](https://github.com/gvolpe/sunix).

## SUNix Report: Home Manager #niri-hdmi :rocket:

**Summary:** 94 added, 94 removed, 264 upgraded, 4 downgraded, 85 changed, 5 other

- **Paths:** 2494 -> 2468 (+1791, -1817)
- **Size:** 19.4 GiB -> 19.9 GiB (+554 MiB)

<details>
<summary><strong>Added</strong> (94)</summary>

| Category | Name | Version | Size |
| --- | --- | --- | --- |
| [A+] | check-phase-thread-limit-hook | <none> | +1.52 KiB |
| [A+] | hdrhistogram_c | 0.11.10 | +431 KiB |
| [A+] | ldacbt | 2.0.72 | +98.7 KiB |
| [A+] | libresidfp | 1.1.2 | +133 KiB |
| [A+] | librewolf-native-messaging-hosts | <none> | +1.2 KiB |
| [A+] | merve | 1.2.2 | +106 KiB |
| [A+] | nbytes | 0.1.4 | +46.4 KiB |
| [A+] | perl5.42.0-Compress-Raw-Bzip2 | 2.218 | +56.7 KiB |
| [A+] | perl5.42.0-Compress-Raw-Zlib | 2.222 | +130 KiB |
| [A+] | perl5.42.0-IO-Compress | 2.221 | +886 KiB |
| [A+] | python3.14-aiodns | 4.0.4 | +128 KiB |
| [A+] | python3.14-aiohappyeyeballs | 2.7.1 | +95.6 KiB |
| [A+] | python3.14-aiohttp | 3.14.3 | +4.57 MiB |
| [A+] | python3.14-aiosignal | 1.4.0 | +27.2 KiB |
| [A+] | python3.14-aiostream | 0.7.1 | +448 KiB |
| [A+] | python3.14-attrs | 26.1.0 | +665 KiB |
| [A+] | python3.14-brotli | 1.2.0 | +48.9 KiB |
| [A+] | python3.14-certifi | 2026.06.17 | +483 KiB |
| [A+] | python3.14-cffi | 2.1.0 | +1.47 MiB |
| [A+] | python3.14-charset-normalizer | 3.4.9 | +1.09 MiB |
| [A+] | python3.14-click | 8.3.3 | +1.39 MiB |
| [A+] | python3.14-click-log | 0.4.0 | +24.1 KiB |
| [A+] | python3.14-configobj | 5.0.9 | +408 KiB |
| [A+] | python3.14-cryptography | 49.0.0 | +6.41 MiB |
| [A+] | python3.14-curl-cffi | 0.15.0 | +1.23 MiB |
| [A+] | python3.14-dbus-python | 1.4.0 | +692 KiB |
| [A+] | python3.14-dnspython | 2.8.0 | +4.09 MiB |
| [A+] | python3.14-docopt | 0.6.2 | +107 KiB |
| [A+] | python3.14-fido2 | 2.2.1 | +1.95 MiB |
| [A+] | python3.14-freezegun | 1.5.5 | +213 KiB |
| [A+] | python3.14-frozenlist | 1.8.0 | +167 KiB |
| [A+] | python3.14-gp-saml-gui | 0.1+20240731-c46af04 | +173 KiB |
| [A+] | python3.14-icalendar | 7.2.0 | +5.11 MiB |
| [A+] | python3.14-idna | 3.18 | +667 KiB |
| [A+] | python3.14-imageio | 2.37.2 | +3.67 MiB |
| [A+] | python3.14-imageio-ffmpeg | 0.6.0 | +136 KiB |
| [A+] | python3.14-jaraco-classes | 3.4.0 | +53.7 KiB |
| [A+] | python3.14-jaraco-context | 6.1.0 | +47.8 KiB |
| [A+] | python3.14-jaraco-functools | 4.4.0 | +79.3 KiB |
| [A+] | python3.14-jeepney | 0.9 | +608 KiB |
| [A+] | python3.14-keyring | 25.7.0 | +397 KiB |
| [A+] | python3.14-keyutils | 0.6 | +151 KiB |
| [A+] | python3.14-lxml | 6.1.1 | +6.41 MiB |
| [A+] | python3.14-mako | 1.3.12 | +1.01 MiB |
| [A+] | python3.14-markdown | 3.10.2 | +1.16 MiB |
| [A+] | python3.14-markdown-it-py | 4.2.0 | +881 KiB |
| [A+] | python3.14-markupsafe | 3.0.3 | +99.7 KiB |
| [A+] | python3.14-mdurl | 0.1.2 | +68 KiB |
| [A+] | python3.14-more-itertools | 11.1.0 | +790 KiB |
| [A+] | python3.14-mss | 10.1.0 | +248 KiB |
| [A+] | python3.14-multidict | 6.7.1 | +367 KiB |
| [A+] | python3.14-mutagen | 1.47.0 | +2.31 MiB |
| [A+] | python3.14-numpy | 2.5.1 | +51.2 MiB |
| [A+] | python3.14-packaging | 26.2 | +1.25 MiB |
| [A+] | python3.14-pillow | 12.3.0 | +5.11 MiB |
| [A+] | python3.14-pkginfo | 1.12.1.2 | +375 KiB |
| [A+] | python3.14-platformdirs | 4.10.0 | +465 KiB |
| [A+] | python3.14-propcache | 0.5.2 | +155 KiB |
| [A+] | python3.14-psutil | 7.2.2 | +1.16 MiB |
| [A+] | python3.14-pycairo | 1.29.0 | +508 KiB |
| [A+] | python3.14-pycares | 5.0.1 | +632 KiB |
| [A+] | python3.14-pycparser | 3.00 | +736 KiB |
| [A+] | python3.14-pycryptodomex | 3.23.0 | +9.55 MiB |
| [A+] | python3.14-pygments | 2.20.0 | +12.8 MiB |
| [A+] | python3.14-pygobject | 3.56.3-dev, 3.56.3 | +1.21 MiB |
| [A+] | python3.14-pyscard | 2.3.1 | +1.23 MiB |
| [A+] | python3.14-pyserial | 3.5 | +1.09 MiB |
| [A+] | python3.14-python-dateutil | 2.9.0.post0 | +1.04 MiB |
| [A+] | python3.14-python-pskc | 1.4 | +522 KiB |
| [A+] | python3.14-python-xapp | 3.0.3 | +214 KiB |
| [A+] | python3.14-pytz | 2026.2 | +2.62 MiB |
| [A+] | python3.14-pyxdg | 0.28 | +631 KiB |
| [A+] | python3.14-pyyaml | 6.0.3 | +1013 KiB |
| [A+] | python3.14-requests | 2.34.2 | +795 KiB |
| [A+] | python3.14-requests-toolbelt | 1.0.0 | +476 KiB |
| [A+] | python3.14-rich | 15.0.0 | +4.56 MiB |
| [A+] | python3.14-screeninfo | 0.8.1 | +133 KiB |
| [A+] | python3.14-secretstorage | 3.5.0 | +140 KiB |
| [A+] | python3.14-setproctitle | 1.3.7 | +49.2 KiB |
| [A+] | python3.14-setuptools | 83.0.0 | +11.1 MiB |
| [A+] | python3.14-six | 1.17.0 | +124 KiB |
| [A+] | python3.14-typing-extensions | 4.16.0 | +531 KiB |
| [A+] | python3.14-tzdata | 2026.3 | +714 KiB |
| [A+] | python3.14-tzlocal | 5.4.4 | +168 KiB |
| [A+] | python3.14-urllib3 | 2.7.0 | +1.46 MiB |
| [A+] | python3.14-urwid | 3.0.5 | +3.8 MiB |
| [A+] | python3.14-vdirsyncer | 0.20.0 | +739 KiB |
| [A+] | python3.14-wcwidth | 0.8.2 | +6.67 MiB |
| [A+] | python3.14-websockets | 16.1 | +2.06 MiB |
| [A+] | python3.14-yarl | 1.24.5 | +570 KiB |
| [A+] | python3.14-yt-dlp-ejs | 0.8.0 | +173 KiB |
| [A+] | python3.14-yubikey-manager | 5.9.2 | +2.83 MiB |
| [A+] | python3.14-zxing-cpp | 3.0.2 | +1.52 MiB |
| [A+] | sox | 14.4.2-unstable-2021-05-09-lib | +702 KiB |

</details>

<details>
<summary><strong>Removed</strong> (94)</summary>

| Category | Name | Version | Size |
| --- | --- | --- | --- |
| [R] | gnome-icon-theme | 3.12.0 | -11.2 MiB |
| [R] | gtk+ | 2.24.33 | -27.1 MiB |
| [R] | gtk-engine-murrine | 0.98.2 | -310 KiB |
| [R] | hm_kittydiff.conf | <none> | -200 B |
| [R] | jmtpfs | 0.5-fish-completions, 0.5 | -145 KiB |
| [R] | python3.13-aiodns | 4.0.4 | -117 KiB |
| [R] | python3.13-aiohappyeyeballs | 2.6.1 | -91 KiB |
| [R] | python3.13-aiohttp | 3.13.5 | -3.81 MiB |
| [R] | python3.13-aiohttp-oauthlib | 0.1.0 | -72.2 KiB |
| [R] | python3.13-aiosignal | 1.4.0 | -25.7 KiB |
| [R] | python3.13-aiostream | 0.7.1 | -401 KiB |
| [R] | python3.13-atomicwrites | 1.4.1 | -37 KiB |
| [R] | python3.13-attrs | 26.1.0 | -648 KiB |
| [R] | python3.13-backports-zstd | 1.3.0 | -1.15 MiB |
| [R] | python3.13-brotli | 1.2.0 | -48.9 KiB |
| [R] | python3.13-certifi | 2026.01.04 | -474 KiB |
| [R] | python3.13-cffi | 2.0.0 | -1.43 MiB |
| [R] | python3.13-charset-normalizer | 3.4.7 | -1024 KiB |
| [R] | python3.13-click | 8.3.1 | -1.23 MiB |
| [R] | python3.13-click-log | 0.4.0 | -23.8 KiB |
| [R] | python3.13-click-threading | 0.5.0 | -38.2 KiB |
| [R] | python3.13-configobj | 5.0.9 | -402 KiB |
| [R] | python3.13-cryptography | 48.0.0 | -6.22 MiB |
| [R] | python3.13-curl-cffi | 0.15.0 | -1.13 MiB |
| [R] | python3.13-dbus-python | 1.4.0 | -685 KiB |
| [R] | python3.13-dnspython | 2.8.0 | -3.8 MiB |
| [R] | python3.13-docopt | 0.6.2 | -105 KiB |
| [R] | python3.13-fido2 | 2.1.1 | -1.75 MiB |
| [R] | python3.13-freezegun | 1.5.5 | -183 KiB |
| [R] | python3.13-frozenlist | 1.8.0 | -167 KiB |
| [R] | python3.13-gp-saml-gui | 0.1+20240731-c46af04 | -171 KiB |
| [R] | python3.13-icalendar | 7.2.0 | -4.82 MiB |
| [R] | python3.13-idna | 3.13 | -860 KiB |
| [R] | python3.13-imageio | 2.37.2 | -3.56 MiB |
| [R] | python3.13-imageio-ffmpeg | 0.6.0 | -135 KiB |
| [R] | python3.13-jaraco-classes | 3.4.0 | -48 KiB |
| [R] | python3.13-jaraco-context | 6.1.0 | -46.4 KiB |
| [R] | python3.13-jaraco-functools | 4.4.0 | -77.9 KiB |
| [R] | python3.13-jeepney | 0.9 | -579 KiB |
| [R] | python3.13-keyring | 25.7.0 | -376 KiB |
| [R] | python3.13-keyutils | 0.6 | -151 KiB |
| [R] | python3.13-lxml | 6.0.2 | -6.35 MiB |
| [R] | python3.13-mako | 1.3.10 | -1015 KiB |
| [R] | python3.13-markdown | 3.10.2 | -1.06 MiB |
| [R] | python3.13-markdown-it-py | 4.0.0 | -752 KiB |
| [R] | python3.13-markupsafe | 3.0.3 | -85.5 KiB |
| [R] | python3.13-mdurl | 0.1.2 | -62.6 KiB |
| [R] | python3.13-more-itertools | 10.8.0 | -733 KiB |
| [R] | python3.13-mss | 10.1.0 | -228 KiB |
| [R] | python3.13-multidict | 6.7.1 | -322 KiB |
| [R] | python3.13-mutagen | 1.47.0 | -2.25 MiB |
| [R] | python3.13-numpy | 2.4.4 | -49.2 MiB |
| [R] | python3.13-oauthlib | 3.3.1 | -1.57 MiB |
| [R] | python3.13-packaging | 26.1 | -1.07 MiB |
| [R] | python3.13-pillow | 12.2.0 | -4.69 MiB |
| [R] | python3.13-pkginfo | 1.12.1.2 | -367 KiB |
| [R] | python3.13-platformdirs | 4.5.1 | -255 KiB |
| [R] | python3.13-propcache | 0.4.1 | -151 KiB |
| [R] | python3.13-psutil | 7.2.2 | -1.14 MiB |
| [R] | python3.13-pycairo | 1.29.0 | -508 KiB |
| [R] | python3.13-pycares | 5.0.1 | -613 KiB |
| [R] | python3.13-pycparser | 3.00 | -660 KiB |
| [R] | python3.13-pycryptodomex | 3.23.0 | -9.35 MiB |
| [R] | python3.13-pygments | 2.20.0 | -11.9 MiB |
| [R] | python3.13-pygobject | 3.56.2-dev, 3.56.2 | -1.18 MiB |
| [R] | python3.13-pyscard | 2.3.1 | -1.21 MiB |
| [R] | python3.13-pyserial | 3.5 | -1.08 MiB |
| [R] | python3.13-python-dateutil | 2.9.0.post0 | -1.01 MiB |
| [R] | python3.13-python-pskc | 1.4 | -475 KiB |
| [R] | python3.13-python-xapp | 3.0.3 | -211 KiB |
| [R] | python3.13-pytz | 2026.1.post1 | -2.6 MiB |
| [R] | python3.13-pyxdg | 0.28 | -613 KiB |
| [R] | python3.13-pyyaml | 6.0.3 | -1007 KiB |
| [R] | python3.13-requests | 2.33.1 | -623 KiB |
| [R] | python3.13-requests-toolbelt | 1.0.0 | -471 KiB |
| [R] | python3.13-rich | 14.3.3 | -3.81 MiB |
| [R] | python3.13-screeninfo | 0.8.1 | -124 KiB |
| [R] | python3.13-secretstorage | 3.5.0 | -125 KiB |
| [R] | python3.13-setproctitle | 1.3.7 | -48.2 KiB |
| [R] | python3.13-setuptools | 80.10.1 | -11.3 MiB |
| [R] | python3.13-six | 1.17.0 | -123 KiB |
| [R] | python3.13-typing-extensions | 4.15.0 | -495 KiB |
| [R] | python3.13-tzdata | 2026.2 | -718 KiB |
| [R] | python3.13-tzlocal | 5.3.1 | -165 KiB |
| [R] | python3.13-urllib3 | 2.6.3 | -1.33 MiB |
| [R] | python3.13-urwid | 3.0.5 | -3.42 MiB |
| [R] | python3.13-vdirsyncer | 0.20.0 | -711 KiB |
| [R] | python3.13-wcwidth | 0.6.0 | -604 KiB |
| [R] | python3.13-websockets | 16.0 | -1.88 MiB |
| [R] | python3.13-yarl | 1.23.0 | -492 KiB |
| [R] | python3.13-yt-dlp-ejs | 0.8.0 | -172 KiB |
| [R] | python3.13-yubikey-manager | 5.9.1 | -2.66 MiB |
| [R] | python3.13-zxing-cpp | 2.3.0 | -1.34 MiB |
| [R] | ubuntu-themes | 24.04 | -38.9 MiB |

</details>

<details>
<summary><strong>Upgraded</strong> (264)</summary>

| Category | Name | Old Version | New Version | Size |
| --- | --- | --- | --- | --- |
| [U.] | 7zz | 26.01 | 26.02 | -4 KiB |
| [U.] | acl | - | 2.4.0 | +9.16 KiB |
| [U.] | alsa-lib | - | 1.2.16.1 | +4.81 KiB |
| [U.] | alsa-ucm-conf | - | 1.2.16.1 | +73.1 KiB |
| [U.] | appstream | 1.1.2 | 1.1.3 | +371 KiB |
| [U.] | attr | - | 2.6.0 | -1.74 KiB |
| [U.] | atuin | 18.16.1 | 18.18.1 | +7.26 MiB |
| [U.] | audit | 4.1.4 | 4.2 | -3.75 KiB |
| [U.] | aws-c-http | - | 0.11.0 | +12.9 KiB |
| [U.] | aws-c-io | - | 0.27.2 | +7.43 KiB |
| [U.] | bash | ... | 5.3p15 | 0 B |
| [U.] | bazecor | 1.8.3 | 1.9.0 | -376 KiB |
| [U.] | bind | 9.20.24 | 9.20.26 | +9.35 KiB |
| [U.] | bitwarden | 2026.6.1 | 2026.7.0 | +598 KiB |
| [U.] | bottom | 0.14.2 | 0.14.6 | +136 KiB |
| [U.] | breeze-icons | 6.27.0 | 6.28.0 | +3.23 KiB |
| [U.] | broot | 1.57.0 | 1.58.0 | +466 KiB |
| [U.] | btrfs-progs | 7.0 | 7.1 | +10.5 KiB |
| [U.] | c-ares | 1.34.6 | 1.34.8 | +13.4 KiB |
| [U.] | claude-code | 2.1.197 | 2.1.220 | +28.1 MiB |
| [U.] | codex | 0.142.3 | 0.146.0 | +129 MiB |
| [U.] | curl | 8.20.0 | 8.21.0 | +55.6 KiB |
| [U.] | dankcalendar | 0.2.0 | 0.3.0 | +800 KiB |
| [U.] | darkreader | 4.9.128 | 4.9.129 | +5.9 KiB |
| [U.] | deno | 2.8.3 | 2.9.4 | +115 MiB |
| [U.] | determinate-nix | 3.21.8 | 3.21.9 | 0 B |
| [U.] | determinate-nix-cmd | 3.21.8 | 3.21.9 | 0 B |
| [U.] | determinate-nix-expr | 3.21.8 | 3.21.9 | 0 B |
| [U.] | determinate-nix-fetchers | 3.21.8 | 3.21.9 | +1.31 KiB |
| [U.] | determinate-nix-flake | 3.21.8 | 3.21.9 | 0 B |
| [U.] | determinate-nix-main | 3.21.8 | 3.21.9 | 0 B |
| [U.] | determinate-nix-store | 3.21.8 | 3.21.9 | 0 B |
| [U.] | determinate-nix-util | 3.21.8 | 3.21.9 | 0 B |
| [U.] | diff-so-fancy | 1.4.10 | 1.4.12 | +7.71 KiB |
| [U.] | dix | 2.1.0 | 2.2.0 | +65.4 KiB |
| [U.] | djvulibre | 3.5.29 | 3.5.30 | -72 B |
| [U.] | docker-compose | 5.2.0 | 5.3.1 | +64.1 KiB |
| [U.] | double-conversion | 3.3.1 | 3.4.0 | +776 B |
| [U.] | electron | 41.9.1 | 42.7.1 | 0 B |
| [U.] | electron-unwrapped | 41.9.1 | 42.7.1 | +36.5 MiB |
| [U.] | elfutils | ... | 0.195 | +43.1 KiB |
| [U.] | ethtool | 7.0 | 7.1 | +720 B |
| [U.] | expat | 2.8.1 | 2.8.2 | +5.25 KiB |
| [U.] | extra-cmake-modules | 6.27.0 | 6.28.0 | +3.27 KiB |
| [U.] | eza | 0.23.4 | 0.23.5 | +486 KiB |
| [U.] | fastfetch | 2.65.1 | 2.66.0 | 0 B |
| [U.] | fastfetch-unwrapped | 2.65.1 | 2.66.0 | +244 KiB |
| [U.] | ffmpeg | 8.1.1 | 8.1.2 | -123 KiB |
| [U.] | file | 5.47 | 5.48 | +137 KiB |
| [U.] | findutils | 4.10.0 | 4.11.0 | +170 KiB |
| [U.] | firefox-beta | 151.0b9 | 153.0b13 | -184 KiB |
| [U.] | firefox-beta-unwrapped | 151.0b9 | 153.0b13 | +14.6 MiB |
| [U.] | fish | 4.8.0 | 4.8.1 | +371 KiB |
| [U.] | fluidsynth | - | 2.5.6 | +7.95 KiB |
| [U.] | fontconfig | 2.17.1 | 2.18.2 | +172 KiB |
| [U.] | fzf | 0.73.1 | 0.74.2 | +103 KiB |
| [U.] | game-music-emu | - | 0.6.5 | +2.59 KiB |
| [U.] | gawk | 5.4.0 | 5.4.1 | +39.7 KiB |
| [U.] | gcc | ... | 15.3.0 | -9.53 MiB |
| [U.] | geoclue | 2.7.2 | 2.8.1 | +21.8 KiB |
| [U.] | getopt-util-linux | 2.42 | 2.42.2 | 0 B |
| [U.] | gfortran | 15.2.0 | 15.3.0 | -8.35 KiB |
| [U.] | giflib | - | 6.1.3 | +68.4 KiB |
| [U.] | git | 2.54.0 | 2.55.0 | +1.05 MiB |
| [U.] | glslang | 16.2.0 | 16.3.0 | +214 KiB |
| [U.] | gnused | - | 4.10 | +79 KiB |
| [U.] | gpgme | 2.0.1 | 2.1.2 | +3.98 KiB |
| [U.] | gpgmepp | 2.0.0 | 2.1.0 | +976 B |
| [U.] | graphite2 | 1.3.14 | 1.3.15 | -4.27 KiB |
| [U.] | graphviz | 12.2.1 | 15.1.0 | +276 KiB |
| [U.] | gssdp | - | 1.6.6 | +480 B |
| [U.] | gst-libav | 1.26.11 | 1.28.5 | +336 B |
| [U.] | gst-plugins-bad | - | 1.28.5 | +772 KiB |
| [U.] | gst-plugins-base | - | 1.28.5 | +164 KiB |
| [U.] | gst-plugins-good | 1.26.11 | 1.28.5 | +165 KiB |
| [U.] | gst-plugins-ugly | 1.26.11 | 1.28.5 | +13.8 KiB |
| [U.] | gstreamer | 1.26.11 | 1.28.5 | +195 KiB |
| [U.] | gtest | ... | 1.17.0 | +1.03 MiB |
| [U.] | gupnp | - | 1.6.10 | +88 B |
| [U.] | handy | 0.8.3 | 0.9.1 | +59.7 MiB |
| [U.] | htop | 3.5.1 | 3.5.2 | +4.44 KiB |
| [U.] | hunspell | 1.7.2 | 1.7.3 | +17.9 KiB |
| [U.] | hwdata | ... | 0.409 | +142 KiB |
| [U.] | hwloc | 2.13.0 | 2.14.0 | +8.19 KiB |
| [U.] | hyphen | 2.8.8 | 2.8.9 | +1.27 KiB |
| [U.] | hyprutils | 0.13.1 | 0.14.0 | +62.9 KiB |
| [U.] | imagemagick | 7.1.2-24 | 7.1.2-29 | +134 KiB |
| [U.] | insomnia | 12.2.0 | 13.0.0 | +262 MiB |
| [U.] | inxi | 3.3.40-1 | 3.3.41-1 | +1.2 KiB |
| [U.] | iproute2 | 7.0.0 | 7.1.0 | +6.32 KiB |
| [U.] | jq | 1.8.1 | 1.8.2 | +8.18 KiB |
| [U.] | jsoncpp | 1.9.7 | 1.9.8 | +320 B |
| [U.] | jujutsu | 0.42.0 | 0.43.0 | +1.39 MiB |
| [U.] | karchive | 6.27.0 | 6.28.0 | 0 B |
| [U.] | kcoreaddons | 6.27.0 | 6.28.0 | +45.5 KiB |
| [U.] | kimageformats | 6.27.0 | 6.28.0 | +1.6 KiB |
| [U.] | kitty | 0.47.4 | 0.48.2 | +2.13 MiB |
| [U.] | kitty-themes | 0-unstable-2026-06-29 | 0-unstable-2026-07-10 | +2.81 KiB |
| [U.] | languagetool | 11.0.1 | 11.0.2 | +32 B |
| [U.] | layer-shell-qt | 6.7.2 | 6.7.3 | -56 B |
| [U.] | lcms2 | ... | 2.19.1 | +584 B |
| [U.] | ldns | 1.9.0 | 1.9.2 | +4.16 KiB |
| [U.] | lerc | ... | 4.1.1 | +4 KiB |
| [U.] | less | 692 | 704 | +11.8 KiB |
| [U.] | libadwaita | 1.9.1 | 1.9.2 | +1.01 KiB |
| [U.] | libapparmor | ... | 5.0.2 | +10.5 KiB |
| [U.] | libarchive | 3.8.7 | 3.8.8 | +4.09 KiB |
| [U.] | libavif | 1.4.1 | 1.4.2 | +16.1 KiB |
| [U.] | libbacktrace | 0-unstable-2024-03-02 | 0-unstable-2026-05-03 | +56 B |
| [U.] | libcap | 2.77 | 2.78 | +32 B |
| [U.] | libcbor | ... | 0.14.0 | +224 B |
| [U.] | libconfig | - | 1.8.2 | +8.49 KiB |
| [U.] | libdisplay-info | 0.3.0 | 0.4.0 | +15 KiB |
| [U.] | libdrm | 2.4.133 | 2.4.134 | +105 KiB |
| [U.] | libdvdcss | - | 1.5.0 | -36.8 KiB |
| [U.] | libdwarf | 2.3.1 | 2.3.2 | +4.02 KiB |
| [U.] | libedit | 20251016-3.1 | 20260508-3.1 | +4.05 KiB |
| [U.] | libevent | - | 2.1.13 | +192 B |
| [U.] | libffi | 3.5.2 | 3.7.1 | -49.6 KiB |
| [U.] | libgpg-error | ... | 1.61 | -2.36 KiB |
| [U.] | libheif | 1.23.0 | 1.23.1 | +12.7 KiB |
| [U.] | libidn | 1.43 | 1.44 | +2.92 KiB |
| [U.] | libjpeg-turbo | 3.1.4 | 3.1.4.1 | +24 B |
| [U.] | libjxl | 0.11.2 | 0.12.0 | -3.52 MiB |
| [U.] | libksba | 1.6.7 | 1.8.0 | +8.45 KiB |
| [U.] | libmd | 1.1.0 | 1.2.0 | +13.8 KiB |
| [U.] | libmicrohttpd | ... | 1.0.6 | +4.11 KiB |
| [U.] | libmpg123 | 1.33.4 | 1.33.6 | -32 B |
| [U.] | libmwaw | 0.3.22 | 0.3.23 | -16.8 KiB |
| [U.] | libmysofa | - | 1.3.4 | -496 B |
| [U.] | libnice | - | 0.1.23 | +176 B |
| [U.] | libopenmpt | - | 0.8.7 | +18.3 KiB |
| [U.] | libpaper | - | 2.2.8 | +57.1 KiB |
| [U.] | libqalculate | 5.11.0 | 5.12.0 | +136 KiB |
| [U.] | librevenge | 0.0.5 | 0.0.6 | +272 B |
| [U.] | librsvg | 2.62.1 | 2.62.3 | +460 KiB |
| [U.] | libseccomp | ... | 2.6.1 | -4.01 KiB |
| [U.] | libsepol | 3.10 | 3.11 | -1.73 KiB |
| [U.] | libsidplayfp | 2.16.1 | 3.0.2 | -322 KiB |
| [U.] | libsodium | 1.0.22-unstable-2026-04-09 | 1.0.22-unstable-2026-07-08 | +2.94 KiB |
| [U.] | libssh | - | 0.12.1 | +40 B |
| [U.] | libtiff | 4.7.1 | 4.7.2 | +31.5 KiB |
| [U.] | libtool | - | 2.6.2 | 0 B |
| [U.] | libtpms | ... | 0.10.2-unstable-2026-05-06 | +14.6 KiB |
| [U.] | libusb | 1.0.29 | 1.0.30 | +6.09 KiB |
| [U.] | libva | - | 2.24.0 | +4.23 KiB |
| [U.] | libva-minimal | - | 2.24.0 | +4.22 KiB |
| [U.] | libwacom | 2.19.0 | 2.19.1 | -48 B |
| [U.] | libxi | 1.8.2 | 1.8.3 | +40 B |
| [U.] | libxkbcommon | 1.13.1 | 1.13.2 | -1.02 MiB |
| [U.] | libxkbfile | 1.1.3 | 1.2.0 | -1.14 KiB |
| [U.] | libxmlb | 0.3.25 | 0.3.27 | +360 B |
| [U.] | libxmp | 4.7.0 | 4.7.1 | +4.41 KiB |
| [U.] | lilv | - | 0.28.0 | +1016 B |
| [U.] | linux-headers | 6.18.7 | 7.1 | +162 KiB |
| [U.] | linux-pam | ... | 1.7.2 | +12.9 KiB |
| [U.] | llhttp | 9.4.1 | 9.4.2 | 0 B |
| [U.] | lttng-ust | 2.14.0 | 2.15.1 | +76.8 KiB |
| [U.] | lvm2 | 2.03.39 | 2.03.41 | +8.05 KiB |
| [U.] | mbedtls | 3.6.6 | 3.6.7 | +8.45 KiB |
| [U.] | md4c | 0.5.2 | 0.5.3 | +8.12 KiB |
| [U.] | mesa-libgbm | ... | 26.1.3 | 0 B |
| [U.] | minizip-ng-compat | 4.2.1 | 4.2.2 | +272 B |
| [U.] | mpg123 | - | 1.33.6 | -32 B |
| [U.] | neovim | 0.12.3 | 0.12.4 | 0 B |
| [U.] | neovim-unwrapped | 0.12.3 | 0.12.4 | +352 B |
| [U.] | nghttp3 | 1.15.0 | 1.16.0 | +5.41 KiB |
| [U.] | ngrok | 3.39.5 | 3.39.9 | -21.8 KiB |
| [U.] | nil | 2025-06-13 | 2026-07-23 | +1.28 MiB |
| [U.] | nix | 2.34.7 | 2.34.8 | -4.3 KiB |
| [U.] | nix-cmd | 2.34.7 | 2.34.8 | -576 B |
| [U.] | nix-expr | 2.34.7 | 2.34.8 | +160 B |
| [U.] | nix-fetchers | 2.34.7 | 2.34.8 | +8.03 KiB |
| [U.] | nix-flake | 2.34.7 | 2.34.8 | -832 B |
| [U.] | nix-main | 2.34.7 | 2.34.8 | -312 B |
| [U.] | nix-nswrapper | 2.34.7 | 2.34.8 | -456 B |
| [U.] | nix-output-monitor | 2.1.8 | 2.2.0 | +453 KiB |
| [U.] | nix-store | 2.34.7 | 2.34.8 | +4.37 KiB |
| [U.] | nix-util | 2.34.7 | 2.34.8 | +4.17 KiB |
| [U.] | nixfmt | 1.3.1 | 1.4.0 | +93.9 KiB |
| [U.] | nodejs | 24.16.0 | 24.18.1 | +31.2 KiB |
| [U.] | nodejs-slim | 24.16.0 | 24.18.1 | +1.82 MiB |
| [U.] | nss | 3.125 | 3.126 | +16.9 KiB |
| [U.] | nss-cacert | 3.123 | 3.126 | +7.62 KiB |
| [U.] | nsticky | 0.3.0 | 0.4.0 | +98.7 KiB |
| [U.] | ntfs3g | 2026.2.25 | 2026.7.7 | +4.2 KiB |
| [U.] | ocl-icd | - | 2.3.5 | +20.6 KiB |
| [U.] | onnxruntime | 1.26.0 | 1.27.1 | +1.45 MiB |
| [U.] | openexr | 3.4.11 | 3.4.13 | +8.85 KiB |
| [U.] | openjdk | 25.0.4+1 | 25.0.4+7 | +829 KiB |
| [U.] | openjdk-minimal-jre | 21.0.12+2 | 21.0.12+8 | -137 KiB |
| [U.] | openresolv | 3.17.0 | 3.17.4 | +760 B |
| [U.] | openssh | 10.3p1 | 10.4p1 | +1.08 MiB |
| [U.] | openssl | 3.6.2 | 3.6.3 | +7.88 KiB |
| [U.] | orc | - | 0.4.42 | +403 KiB |
| [U.] | ostree | 2026.1 | 2026.2 | +64 B |
| [U.] | pcre2 | 10.46 | 10.47 | +118 KiB |
| [U.] | pear-desktop | 3.11.0 | 3.12.0 | +2.06 MiB |
| [U.] | pedantix | 1.0.0 | 1.1.0 | +64.7 KiB |
| [U.] | perl5.42.0-Cpanel-JSON-XS | 4.37 | 4.42 | +2.38 KiB |
| [U.] | perl5.42.0-HTML-Parser | - | 3.85 | +136 B |
| [U.] | perl5.42.0-HTTP-Message | - | 7.02 | +512 B |
| [U.] | perl5.42.0-libwww-perl | - | 6.83 | +6.24 KiB |
| [U.] | pipewire | 1.6.5 | 1.6.8 | -14 KiB |
| [U.] | poppler-glib | 25.10.0 | 26.06.0 | +370 KiB |
| [U.] | poppler-utils | 25.10.0 | 26.06.0 | +415 KiB |
| [U.] | procps | ... | 4.0.6 | -81.7 KiB |
| [U.] | protobuf | 34.1 | 35.1 | +346 KiB |
| [U.] | psqlodbc | 18.00.0001 | 18.00.0002 | +4.09 KiB |
| [U.] | publicsuffix-list | 0-unstable-2026-05-13 | 0-unstable-2026-06-24 | +448 B |
| [U.] | python3 | 3.13.13 | 3.14.6 | +8.05 MiB |
| [U.] | qtkeychain | 0.16.0 | 0.17.0 | -744 B |
| [U.] | reaper | 7.75 | 7.78 | +49.8 KiB |
| [U.] | ripgrep | 15.1.0 | 15.2.0 | +539 KiB |
| [U.] | s2n-tls | 1.7.2 | 1.7.6 | -28.5 KiB |
| [U.] | sdl2-compat | 2.32.68 | 2.32.70 | 0 B |
| [U.] | sdl3 | 3.4.10 | 3.4.12 | +14.3 KiB |
| [U.] | serd | - | 0.32.10 | 0 B |
| [U.] | slack | 4.49.89 | 4.51.180 | +19 MiB |
| [U.] | socat | 1.8.1.1 | 1.8.1.3 | 0 B |
| [U.] | sord | - | 0.16.22 | +56 B |
| [U.] | spidermonkey | 140.9.0 | 140.13.0 | +22.2 KiB |
| [U.] | spotify | 1.2.90.451.gb094aab0 | 1.2.92.147.g5b8f9367 | +717 KiB |
| [U.] | sqlite | 3.51.2 | 3.53.3 | -5.48 MiB |
| [U.] | srt | - | 1.5.6 | +183 KiB |
| [U.] | svt-av1 | - | 4.1.0 | -777 KiB |
| [U.] | syntax-highlighting | 6.27.0 | 6.28.0 | +27.6 KiB |
| [U.] | systemctl-tui | 0.5.2 | 0.8.0 | -580 KiB |
| [U.] | systemd | 260.2 | 261.1 | +1.89 MiB |
| [U.] | systemd-minimal | 260.2 | 261.1 | +1.61 MiB |
| [U.] | systemd-minimal-libs | 260.2 | 261.1 | +225 KiB |
| [U.] | telegram-desktop | 6.9.3 | 7.0.2 | +11.1 MiB |
| [U.] | tree-sitter | 0.26.8 | 0.26.9 | +422 KiB |
| [U.] | tree-sitter-c-neovim | 0.12.3 | 0.12.4 | 0 B |
| [U.] | tree-sitter-lua-neovim | 0.12.3 | 0.12.4 | 0 B |
| [U.] | tree-sitter-markdown-neovim | 0.12.3 | 0.12.4 | 0 B |
| [U.] | tree-sitter-markdown_inline-neovim | 0.12.3 | 0.12.4 | 0 B |
| [U.] | tree-sitter-query-neovim | 0.12.3 | 0.12.4 | 0 B |
| [U.] | tree-sitter-vim-neovim | 0.12.3 | 0.12.4 | 0 B |
| [U.] | tree-sitter-vimdoc-neovim | 0.12.3 | 0.12.4 | 0 B |
| [U.] | tzdata | 2026b | 2026c | -9.41 KiB |
| [U.] | ublock-origin | 1.72.0 | 1.72.2 | -37 KiB |
| [U.] | unbound | 1.25.1 | 1.25.2 | +4.19 KiB |
| [U.] | util-linux | 2.42 | 2.42.2 | +237 KiB |
| [U.] | util-linux-minimal | 2.42 | 2.42.2 | +32 KiB |
| [U.] | vpnc-scripts-unstable | 2023-01-03 | 2026-06-29 | +1.19 KiB |
| [U.] | vulkan-headers | 1.4.341.0 | 1.4.350.0 | +2.71 MiB |
| [U.] | vulkan-loader | 1.4.341.0 | 1.4.350.0 | -684 KiB |
| [U.] | wayland | 1.25.0 | 1.26.0 | -250 KiB |
| [U.] | wayland-protocols | 1.48 | 1.49 | +5.75 KiB |
| [U.] | wayland-scanner | 1.25.0 | 1.26.0 | +3.48 KiB |
| [U.] | webkitgtk | 2.52.4+abi=4.1 | 2.52.5+abi=4.1 | +474 KiB |
| [U.] | which | 2.23 | 2.25 | +8 B |
| [U.] | x265 | - | 4.2 | +143 KiB |
| [U.] | xfsprogs | 7.0.1 | 7.1.1 | +2.24 KiB |
| [U.] | xgcc | ... | 15.3.0 | -193 KiB |
| [U.] | xkeyboard-config | ... | 2.48 | -10.3 MiB |
| [U.] | xz | ... | 5.8.3 | +229 KiB |
| [U.] | yt-dlp | 2026.06.09 | 2026.07.04 | +1.01 MiB |
| [U.] | yubioath-flutter | 7.3.3 | 7.4.1 | -3.63 MiB |
| [U.] | yubioath-flutter-helper | 7.3.3 | 7.4.1 | +22.6 KiB |
| [U.] | zix | - | 0.8.2 | +3.07 KiB |
| [U.] | zoxide | 0.9.9 | 0.10.0 | +98.2 KiB |
| [U.] | zxing-cpp | - | 3.0.2 | -198 KiB |

</details>

<details>
<summary><strong>Downgraded</strong> (4)</summary>

| Category | Name | Old Version | New Version | Size |
| --- | --- | --- | --- | --- |
| [D] | elementary-icon-theme | 8.2.0-unstable-2026-07-06 | 8.2.0 | +386 KiB |
| [D] | gperftools | 2.17.2 | ... | -4.83 MiB |
| [D] | icu4c | 76.1 | ... | -44 MiB |
| [D] | nixos-option | 26.11 | <none> | +16 B |

</details>

<details>
<summary><strong>Changed</strong> (85)</summary>

| Category | Name | Version | Size |
| --- | --- | --- | --- |
| [C] | bat | - | +87.4 KiB |
| [C] | boost | - | +15.9 KiB |
| [C] | clang | - | -45.6 KiB |
| [C] | container-init | - | -132 KiB |
| [C] | ddcutil | - | -12 KiB |
| [C] | diskonaut | - | +61.9 KiB |
| [C] | exempi | - | -10.1 KiB |
| [C] | fd | - | +58.1 KiB |
| [C] | flac | - | -19.3 KiB |
| [C] | gcr | - | -40.3 KiB |
| [C] | gdk-pixbuf-loaders.cache | <none> (2 -> 3) | +5.06 KiB |
| [C] | gegl | - | -20.1 KiB |
| [C] | ghostscript-with-X | - | -11.9 KiB |
| [C] | glibc | 2.42-67 (2 -> 1), ... | -33.5 MiB |
| [C] | glycin-loaders | - | +780 KiB |
| [C] | gpu-usage-waybar | - | +64 KiB |
| [C] | gram | - | +14 MiB |
| [C] | home-manager-path | - | +15.6 KiB |
| [C] | hub-unstable | - | +8.3 KiB |
| [C] | hyperfine | - | +21.6 KiB |
| [C] | hyprpicker | - | -14.5 KiB |
| [C] | imlib2 | - | +13.1 KiB |
| [C] | index-x86_64-linux-small | - | -10.6 KiB |
| [C] | jemalloc | - | +299 KiB |
| [C] | khal | - | +159 KiB |
| [C] | kooha | - | +117 KiB |
| [C] | ldacBT | 2.0.2.3 (2 -> 1) | -88.7 KiB |
| [C] | libabw | - | +88.8 KiB |
| [C] | libdovi | - | -46.6 KiB |
| [C] | libdvdread | - | -9.68 KiB |
| [C] | libetonyek | - | +38.8 KiB |
| [C] | libfreehand | - | +110 KiB |
| [C] | libftdi | - | -38.4 KiB |
| [C] | libglvnd | 1.7.0 (4 -> 3), ... | -2.5 MiB |
| [C] | libidn2 | 2.3.8 (4 -> 3), ... | -360 KiB |
| [C] | liborcus | - | -40 KiB |
| [C] | libreoffice | - | -42.4 KiB |
| [C] | libultrahdr | - | -263 KiB |
| [C] | libunistring | 1.4.2 (3 -> 2), ... | -1.98 MiB |
| [C] | libvmaf | - | -12.5 KiB |
| [C] | libwps | - | -12.9 KiB |
| [C] | libx11 | 1.8.13 (3 -> 2), ... | -2.58 MiB |
| [C] | libxau | 1.0.12 (3 -> 2), ... | -27.1 KiB |
| [C] | libxcb | 1.17.0 (4 -> 3), ... | -1.38 MiB |
| [C] | libxdmcp | 1.1.5 (3 -> 2), ... | -31.2 KiB |
| [C] | libxext | 1.3.7 (3 -> 2), ... | -93.7 KiB |
| [C] | libxml2 | 2.15.3 (2 -> 1), ... | -1.39 MiB |
| [C] | libzmf | - | -60.9 KiB |
| [C] | llvm | - | -35.8 KiB |
| [C] | lnav | - | +751 KiB |
| [C] | loupe | - | +314 KiB |
| [C] | man-cache | - | +16 KiB |
| [C] | mupdf | - | -12 KiB |
| [C] | networkmanager | - | -8.26 KiB |
| [C] | nitch | - | -25.1 KiB |
| [C] | nix-index | - | +585 KiB |
| [C] | nixpkgs-fmt | - | +85.5 KiB |
| [C] | openal-soft | - | -8.7 KiB |
| [C] | openvino | - | -777 KiB |
| [C] | pciutils | - | +58.5 KiB |
| [C] | perl5.42.0-Net-SSLeay | - | -20 KiB |
| [C] | pulseaudio | - | -11.5 KiB |
| [C] | qtdeclarative | - | -100 KiB |
| [C] | qtquick3d | - | -16.2 KiB |
| [C] | requestly | - | +25.2 KiB |
| [C] | resvg | - | +348 KiB |
| [C] | rubberband | - | -15.8 KiB |
| [C] | rust-analyzer-unwrapped | - | +5.29 MiB |
| [C] | rust-lib-src | - | +23.7 MiB |
| [C] | samba | - | -8.35 KiB |
| [C] | satty | - | +272 KiB |
| [C] | sd-switch | - | +117 KiB |
| [C] | source | - | +2.92 MiB |
| [C] | sox-unstable | 2021-05-09-lib (2 -> 1) | -702 KiB |
| [C] | sunix | - | +9.29 KiB |
| [C] | thin-provisioning-tools | - | +167 KiB |
| [C] | udiskie | - | +16 KiB |
| [C] | vlc | - | -20.3 KiB |
| [C] | vscode-extension-vadimcn-vscode-lldb | - | +284 KiB |
| [C] | waybar | - | -32.5 KiB |
| [C] | waypaper | - | +33.7 KiB |
| [C] | yazi | - | +1.27 MiB |
| [C] | zathura | - | +36.3 KiB |
| [C] | zlib | 1.3.2 (4 -> 3), ... | -129 KiB |
| [C] | zstd | 1.5.7 (4 -> 3), ... | -1.15 MiB |

</details>

<details>
<summary><strong>Mixed</strong> (5)</summary>

| Category | Name | Version | Size |
| --- | --- | --- | --- |
| [?] | bash-interactive | 5.3p9-man -> 5.3p15-man, 5.3p15 x2, 5.3p9 (3 -> 1), ... | -7.98 KiB |
| [?] | ffmpeg-headless | 8.1.1-bin -> 8.1.2-bin, 8.1.1-data -> 8.1.2-data, 8.1.1-lib -> 8.1.2-lib, 4.4.8-data, 4.4.8-lib, ... | -26.6 MiB |
| [?] | fuse | 3.17.4 -> 3.18.2, 2.9.9 | -234 KiB |
| [?] | ngtcp2 | 1.22.1-dev -> 1.23.0-dev, 1.24.0 -> 1.23.0, 1.25.0, 1.22.1 (2 -> 1), ... | +51.6 KiB |
| [?] | vicinae | 0.22.3-configured-fish-completions -> 0.23.2-fish-completions, 0.22.3 -> 0.23.2, 0.22.3-configured | +857 KiB |

</details>

## SUNix Report: NixOS #aorus :rocket:

**Summary:** 30 added, 52 removed, 193 upgraded, 6 downgraded, 45 changed, 3 other

- **Paths:** 1765 -> 1743 (+1728, -1750)
- **Size:** 12.9 GiB -> 13 GiB (+107 MiB)

<details>
<summary><strong>Added</strong> (30)</summary>

| Category | Name | Version | Size |
| --- | --- | --- | --- |
| [A+] | bcachefs-tools | 1.38.8 | +9.58 MiB |
| [A+] | brltty | 6.9.1 | +9.24 MiB |
| [A+] | execline | 2.9.9.2-bin, 2.9.9.2-lib | +1.37 MiB |
| [A+] | ldacbt | 2.0.72 x2 | +184 KiB |
| [A+] | mimalloc | 3.3.2 | +1003 KiB |
| [A+] | pam.d | <none> | +37.1 KiB |
| [A+] | perl5.42.0-Compress-Raw-Bzip2 | 2.218 | +56.7 KiB |
| [A+] | perl5.42.0-Compress-Raw-Zlib | 2.222 | +130 KiB |
| [A+] | perl5.42.0-IO-Compress | 2.221 | +886 KiB |
| [A+] | python3.14-certifi | 2026.06.17 | +483 KiB |
| [A+] | python3.14-charset-normalizer | 3.4.9 | +1.09 MiB |
| [A+] | python3.14-dbus-python | 1.4.0 | +692 KiB |
| [A+] | python3.14-dnspython | 2.8.0 | +4.09 MiB |
| [A+] | python3.14-idna | 3.18 | +667 KiB |
| [A+] | python3.14-libevdev | 0.13.1 | +395 KiB |
| [A+] | python3.14-libvirt-python | 12.4.0 | +2.04 MiB |
| [A+] | python3.14-markdown | 3.10.2 | +1.16 MiB |
| [A+] | python3.14-pycairo | 1.29.0 | +508 KiB |
| [A+] | python3.14-pygobject | 3.56.3 | +1.18 MiB |
| [A+] | python3.14-pyudev | 0.24.4 | +533 KiB |
| [A+] | python3.14-pyxdg | 0.28 | +631 KiB |
| [A+] | python3.14-pyyaml | 6.0.3 | +1013 KiB |
| [A+] | python3.14-requests | 2.34.2 | +795 KiB |
| [A+] | python3.14-setuptools | 83.0.0 | +11.1 MiB |
| [A+] | python3.14-six | 1.17.0 | +124 KiB |
| [A+] | python3.14-urllib3 | 2.7.0 | +1.46 MiB |
| [A+] | s6 | 2.15.1.0 | +2.58 MiB |
| [A+] | sox | 14.4.2-unstable-2021-05-09-lib x2 | +1.37 MiB |
| [A+] | tcl | 8.6.16 | +7.38 MiB |
| [A+] | zint | 2.16.0-lib | +1014 KiB |

</details>

<details>
<summary><strong>Removed</strong> (52)</summary>

| Category | Name | Version | Size |
| --- | --- | --- | --- |
| [R] | chfn.pam | <none> | -1.46 KiB |
| [R] | chpasswd.pam | <none> | -1.46 KiB |
| [R] | chsh.pam | <none> | -1.46 KiB |
| [R] | cups.pam | <none> | -1.34 KiB |
| [R] | gperftools | 2.17.2 | -4.83 MiB |
| [R] | greetd.pam | <none> | -2.17 KiB |
| [R] | groupadd.pam | <none> | -1.46 KiB |
| [R] | groupdel.pam | <none> | -1.46 KiB |
| [R] | groupmems.pam | <none> | -1.46 KiB |
| [R] | groupmod.pam | <none> | -1.46 KiB |
| [R] | ldacBT | 2.0.2.3 x2 | -163 KiB |
| [R] | libidn | 1.43 x2 | -844 KiB |
| [R] | login.pam | <none> | -2.32 KiB |
| [R] | lynx | 2.9.3 | -2.21 MiB |
| [R] | nixos-option_fish-completions | <none> | -736 B |
| [R] | other.pam | <none> | -1.16 KiB |
| [R] | passwd.pam | <none> | -1.34 KiB |
| [R] | pipewire-extra-config | <none> | -1.12 KiB |
| [R] | python3.13-certifi | 2026.01.04 | -474 KiB |
| [R] | python3.13-charset-normalizer | 3.4.7 | -1024 KiB |
| [R] | python3.13-dbus-python | 1.4.0 | -685 KiB |
| [R] | python3.13-dnspython | 2.8.0 | -3.8 MiB |
| [R] | python3.13-idna | 3.13 | -860 KiB |
| [R] | python3.13-libevdev | 0.13.1 | -363 KiB |
| [R] | python3.13-libvirt | 12.4.0 | -1.86 MiB |
| [R] | python3.13-markdown | 3.10.2 | -1.06 MiB |
| [R] | python3.13-pycairo | 1.29.0 | -508 KiB |
| [R] | python3.13-pygobject | 3.56.2 | -1.15 MiB |
| [R] | python3.13-pyudev | 0.24.4 | -530 KiB |
| [R] | python3.13-pyxdg | 0.28 | -613 KiB |
| [R] | python3.13-pyyaml | 6.0.3 | -1007 KiB |
| [R] | python3.13-requests | 2.33.1 | -623 KiB |
| [R] | python3.13-setuptools | 80.10.1 | -11.3 MiB |
| [R] | python3.13-six | 1.17.0 | -123 KiB |
| [R] | python3.13-urllib3 | 2.6.3 | -1.33 MiB |
| [R] | runuser-l.pam | <none> | -1.31 KiB |
| [R] | runuser.pam | <none> | -1.16 KiB |
| [R] | sdnotify-wrapper | <none> | -96 B |
| [R] | sdnotify-wrapper-bin | <none> | -17.2 KiB |
| [R] | sdnotify-wrapper-doc | <none> | -2.73 KiB |
| [R] | sdnotify-wrapper.c | <none> | -5.92 KiB |
| [R] | sox-unstable | 2021-05-09-lib x2 | -1.37 MiB |
| [R] | sshd.pam | <none> | -1.59 KiB |
| [R] | su.pam | <none> | -1.8 KiB |
| [R] | sudo.pam | <none> | -1.34 KiB |
| [R] | swaylock.pam | <none> | -1.34 KiB |
| [R] | systemd-run0.pam | <none> | -1.46 KiB |
| [R] | systemd-user.pam | <none> | -1.59 KiB |
| [R] | useradd.pam | <none> | -1.46 KiB |
| [R] | userdel.pam | <none> | -1.46 KiB |
| [R] | usermod.pam | <none> | -1.46 KiB |
| [R] | vlock.pam | <none> | -1.34 KiB |

</details>

<details>
<summary><strong>Upgraded</strong> (193)</summary>

| Category | Name | Old Version | New Version | Size |
| --- | --- | --- | --- | --- |
| [U.] | acl | 2.3.2 | 2.4.0 | +30.4 KiB |
| [U.] | alsa-lib | 1.2.15.3 | 1.2.16.1 | +9.46 KiB |
| [U.] | alsa-ucm-conf | 1.2.15.3 | 1.2.16.1 | +146 KiB |
| [U.] | appstream | 1.1.2 | 1.1.3 | +371 KiB |
| [U.] | attr | 2.5.2 | 2.6.0 | +14 KiB |
| [U.] | audit | 4.1.4 | 4.2 | +432 B |
| [U.] | aws-c-http | 0.10.4 | 0.11.0 | +12.9 KiB |
| [U.] | aws-c-io | 0.22.0 | 0.27.2 | +7.43 KiB |
| [U.] | bash-completion | 2.17.0 | 2.18.0 | -3.38 KiB |
| [U.] | bind | 9.20.24 | 9.20.26 | +4.76 KiB |
| [U.] | btrfs-progs | 7.0 | 7.1 | +10.5 KiB |
| [U.] | cage | 0.3.0 | 0.3.1 | +8 B |
| [U.] | cloud-hypervisor | 52.0 | 53.0 | +3.76 MiB |
| [U.] | curl | 8.20.0 | 8.21.0 | +62.7 KiB |
| [U.] | dash | 0.5.13.3 | 0.5.13.5 | +144 B |
| [U.] | dix | 2.1.0 | 2.2.0 | +65.4 KiB |
| [U.] | docker | 29.6.0 | 29.6.2 | +104 B |
| [U.] | docker-buildx | 0.31.1 | 0.35.0 | -24.1 MiB |
| [U.] | docker-compose | 5.2.0 | 5.3.1 | +64.1 KiB |
| [U.] | docker-containerd | 29.6.0 | 29.6.2 | +48.3 KiB |
| [U.] | docker-runc | 29.6.0 | 29.6.2 | 0 B |
| [U.] | docker-tini | 29.6.0 | 29.6.2 | -4 KiB |
| [U.] | elfutils | 0.194 | 0.195 | +86.7 KiB |
| [U.] | ethtool | 7.0 | 7.1 | +5.46 KiB |
| [U.] | expat | 2.8.1 | 2.8.2 | +10.5 KiB |
| [U.] | ffmpeg | 8.1.1 | 8.1.2 | -11.4 KiB |
| [U.] | ffmpeg-headless | 8.1.1 | 8.1.2 | +8.14 KiB |
| [U.] | file | 5.47 | 5.48 | +274 KiB |
| [U.] | findutils | 4.10.0 | 4.11.0 | +174 KiB |
| [U.] | fish | 4.8.0 | 4.8.1 | +371 KiB |
| [U.] | fluidsynth | 2.5.3 | 2.5.6 | +7.95 KiB |
| [U.] | fontconfig | 2.17.1 | 2.18.2 | +321 KiB |
| [U.] | game-music-emu | 0.6.4 | 0.6.5 | +2.59 KiB |
| [U.] | gamescope | 3.16.24 | 3.16.25 | +233 KiB |
| [U.] | gawk | 5.4.0 | 5.4.1 | +43.6 KiB |
| [U.] | gcc | 15.2.0 | 15.3.0 | +319 KiB |
| [U.] | geoclue | 2.7.2 | 2.8.1 | +21.8 KiB |
| [U.] | giflib | 5.2.2 | 6.1.3 | +129 KiB |
| [U.] | git-minimal | 2.54.0 | 2.55.0 | +892 KiB |
| [U.] | gnused | 4.9 | 4.10 | +163 KiB |
| [U.] | gpgme | 2.0.1 | 2.1.2 | +3.98 KiB |
| [U.] | graphite2 | 1.3.14 | 1.3.15 | 0 B |
| [U.] | gssdp | 1.6.4 | 1.6.6 | +480 B |
| [U.] | gst-plugins-bad | 1.26.11 | 1.28.5 | +772 KiB |
| [U.] | gst-plugins-base | 1.26.11 | 1.28.5 | +358 KiB |
| [U.] | gst-plugins-good | 1.26.11 | 1.28.5 | +165 KiB |
| [U.] | gstreamer | 1.26.11 | 1.28.5 | +393 KiB |
| [U.] | gupnp | 1.6.9 | 1.6.10 | +88 B |
| [U.] | hunspell | 1.7.2 | 1.7.3 | +17.9 KiB |
| [U.] | hwdata | 0.406 | 0.409 | +285 KiB |
| [U.] | hwloc | 2.13.0 | 2.14.0 | +8.19 KiB |
| [U.] | hyphen | 2.8.8 | 2.8.9 | +1.27 KiB |
| [U.] | icu4c | 76.1 | 78.3 | +2.61 MiB |
| [U.] | initrd-linux | 7.1.2 | 7.1.5 | +1.58 MiB |
| [U.] | iproute2 | 7.0.0 | 7.1.0 | +6.24 KiB |
| [U.] | jq | 1.8.1 | 1.8.2 | +8.18 KiB |
| [U.] | lcms2 | 2.18 | 2.19.1 | +5.04 KiB |
| [U.] | ldns | 1.9.0 | 1.9.2 | +4.16 KiB |
| [U.] | lerc | 4.1.0 | 4.1.1 | -21.5 KiB |
| [U.] | less | 692 | 704 | +11.8 KiB |
| [U.] | libadwaita | 1.9.1 | 1.9.2 | +1.01 KiB |
| [U.] | libapparmor | 4.1.7 | 5.0.2 | +20.5 KiB |
| [U.] | libarchive | 3.8.7 | 3.8.8 | +11.4 KiB |
| [U.] | libavif | 1.4.1 | 1.4.2 | +16.1 KiB |
| [U.] | libbacktrace | 0-unstable-2024-03-02 | 0-unstable-2026-05-03 | +56 B |
| [U.] | libcap | 2.77 | 2.78 | +56 B |
| [U.] | libcbor | 0.13.0 | 0.14.0 | +536 B |
| [U.] | libconfig | 1.8 | 1.8.2 | +25 KiB |
| [U.] | libdisplay-info | 0.3.0 | 0.4.0 | +34.1 KiB |
| [U.] | libdrm | 2.4.133 | 2.4.134 | +197 KiB |
| [U.] | libdvdcss | 1.4.3 | 1.5.0 | -36.8 KiB |
| [U.] | libedit | 20251016-3.1 | 20260508-3.1 | +4.16 KiB |
| [U.] | libei | 1.5.0 | 1.6.0 | +32.5 KiB |
| [U.] | libevent | 2.1.12 | 2.1.13 | +360 B |
| [U.] | libffi | 3.5.2 | 3.7.1 | +30.1 KiB |
| [U.] | libgpg-error | 1.59 | 1.61 | -760 B |
| [U.] | libjpeg-turbo | 3.1.4 | 3.1.4.1 | -4.02 KiB |
| [U.] | libjxl | 0.11.2 | 0.12.0 | -3.52 MiB |
| [U.] | libksba | 1.6.7 | 1.8.0 | +8.45 KiB |
| [U.] | libmd | 1.1.0 | 1.2.0 | +13.8 KiB |
| [U.] | libmicrohttpd | 1.0.2 | 1.0.6 | +8.32 KiB |
| [U.] | libmpc | 1.4.0 | 1.4.1 | 0 B |
| [U.] | libmpg123 | 1.33.4 | 1.33.6 | -4.02 KiB |
| [U.] | libmysofa | 1.3.3 | 1.3.4 | -440 B |
| [U.] | libnice | 0.1.22 | 0.1.23 | +176 B |
| [U.] | libopenmpt | 0.8.6 | 0.8.7 | +36.9 KiB |
| [U.] | libpaper | 1.1.29 | 2.2.8 | +57.1 KiB |
| [U.] | libressl | 4.2.1 | 4.3.2 | +14.9 KiB |
| [U.] | librsvg | 2.62.1 | 2.62.3 | +460 KiB |
| [U.] | libseccomp | 2.6.0 | 2.6.1 | -7.89 KiB |
| [U.] | libsodium | 1.0.22-unstable-2026-04-09 | 1.0.22-unstable-2026-07-08 | +2.94 KiB |
| [U.] | libssh | 0.12.0 | 0.12.1 | +4.06 KiB |
| [U.] | libtiff | 4.7.1 | 4.7.2 | +18.1 KiB |
| [U.] | libtool | 2.5.4 | 2.6.2 | 0 B |
| [U.] | libusb | 1.0.29 | 1.0.30 | +9.27 KiB |
| [U.] | libva | 2.23.0 | 2.24.0 | +12.5 KiB |
| [U.] | libva-minimal | 2.23.0 | 2.24.0 | +12.4 KiB |
| [U.] | libwacom | 2.19.0 | 2.19.1 | -48 B |
| [U.] | libxfont_2 | 2.0.7 | 2.0.8 | +3.74 KiB |
| [U.] | libxi | 1.8.2 | 1.8.3 | +24 B |
| [U.] | libxkbcommon | 1.13.1 | 1.13.2 | +36.3 KiB |
| [U.] | libxkbfile | 1.1.3 | 1.2.0 | -1.14 KiB |
| [U.] | libxmlb | 0.3.25 | 0.3.27 | +360 B |
| [U.] | lilv | 0.26.4 | 0.28.0 | +1.93 KiB |
| [U.] | linux | 7.1.2 | 7.1.5 | +73.5 KiB |
| [U.] | linux-headers | 6.18.7 | 7.1 | +162 KiB |
| [U.] | linux-headers-static | 6.18.7 | 7.1 | +162 KiB |
| [U.] | linux-pam | 1.7.1 | 1.7.2 | +23.9 KiB |
| [U.] | llhttp | 9.4.1 | 9.4.2 | 0 B |
| [U.] | lttng-ust | 2.14.0 | 2.15.1 | +116 KiB |
| [U.] | lvm2 | 2.03.39 | 2.03.41 | +39.7 KiB |
| [U.] | mbedtls | 3.6.6 | 3.6.7 | +22.1 KiB |
| [U.] | mesa | 26.1.3 | 26.1.6 | +1.55 MiB |
| [U.] | mesa-libgbm | 26.0.3 | 26.1.3 | 0 B |
| [U.] | moby | 29.6.0 | 29.6.2 | +38.1 KiB |
| [U.] | mpg123 | 1.33.4 | 1.33.6 | -4.02 KiB |
| [U.] | multipath-tools | 0.14.1 | 0.14.3 | +16 B |
| [U.] | neatvnc | 1.0.0 | 1.0.1 | -48 B |
| [U.] | nghttp3 | 1.15.0 | 1.16.0 | +5.15 KiB |
| [U.] | ngtcp2 | 1.22.1 | 1.23.0 | +94 KiB |
| [U.] | niri-unstable | 2026-06-18-49fc611 | 2026-08-02-feb3e43 | -2.76 MiB |
| [U.] | nix | 2.34.7 | 2.35.1 | +308 KiB |
| [U.] | nix-cmd | 2.34.7 | 2.35.1 | +11.1 KiB |
| [U.] | nix-expr | 2.34.7 | 2.35.1 | +63.1 KiB |
| [U.] | nix-fetchers | 2.34.7 | 2.35.1 | +42.8 KiB |
| [U.] | nix-flake | 2.34.7 | 2.35.1 | +11.2 KiB |
| [U.] | nix-main | 2.34.7 | 2.35.1 | -3.2 KiB |
| [U.] | nix-manual | 2.34.7 | 2.35.1 | +1.39 MiB |
| [U.] | nix-nswrapper | 2.34.7 | 2.35.1 | -9.31 KiB |
| [U.] | nix-store | 2.34.7 | 2.35.1 | +905 KiB |
| [U.] | nix-util | 2.34.7 | 2.35.1 | +206 KiB |
| [U.] | nixos-system-aorus | 26.11.20260702.6517942 | 26.11.20260801.148bab9 | +51.7 KiB |
| [U.] | nss-cacert | 3.123 | 3.126 | +19.7 KiB |
| [U.] | ntfs3g | 2026.2.25 | 2026.7.7 | +4.2 KiB |
| [U.] | ocl-icd | 2.3.4 | 2.3.5 | +39.7 KiB |
| [U.] | open-iscsi | 2.1.11 | 2.1.12 | +880 B |
| [U.] | openexr | 3.4.11 | 3.4.13 | +8.85 KiB |
| [U.] | openresolv | 3.17.0 | 3.17.4 | +1.48 KiB |
| [U.] | openssh | 10.3p1 | 10.4p1 | +1.08 MiB |
| [U.] | openssl | 3.6.2 | 3.6.3 | +1.27 MiB |
| [U.] | openvpn | 2.6.19 | 2.6.21 | +4.95 KiB |
| [U.] | orc | 0.4.41 | 0.4.42 | +875 KiB |
| [U.] | ostree | 2026.1 | 2026.2 | +64 B |
| [U.] | passt | 2025_09_19.623dbf6 | 2026_07_16.090d739 | +256 KiB |
| [U.] | pcre2 | 10.46 | 10.47 | +40.4 KiB |
| [U.] | perl5.42.0-Config-IniFiles | 3.000003 | 3.002000 | +88 B |
| [U.] | perl5.42.0-HTML-Parser | 3.81 | 3.85 | +136 B |
| [U.] | perl5.42.0-HTTP-Message | 6.45 | 7.02 | +512 B |
| [U.] | perl5.42.0-libwww-perl | 6.72 | 6.83 | +6.24 KiB |
| [U.] | pipewire | 1.6.5 | 1.6.8 | +1.85 MiB |
| [U.] | poppler-glib | 25.10.0 | 26.06.0 | +370 KiB |
| [U.] | poppler-utils | 25.10.0 | 26.06.0 | +415 KiB |
| [U.] | publicsuffix-list | 0-unstable-2026-05-13 | 0-unstable-2026-06-24 | +896 B |
| [U.] | python3 | 3.13.13 | 3.14.6 | +13.2 MiB |
| [U.] | qemu | 11.0.1 | 11.0.2 | +948 KiB |
| [U.] | s2n-tls | 1.7.2 | 1.7.6 | -28.5 KiB |
| [U.] | sdl2-compat | 2.32.68 | 2.32.70 | 0 B |
| [U.] | sdl3 | 3.4.10 | 3.4.12 | +14.3 KiB |
| [U.] | serd | 0.32.8 | 0.32.10 | 0 B |
| [U.] | skalibs | 2.15.0.0 | 2.15.1.0 | +72 B |
| [U.] | socat | 1.8.1.1 | 1.8.1.3 | 0 B |
| [U.] | sord | 0.16.20 | 0.16.22 | +64 B |
| [U.] | sqlite | 3.51.2 | 3.53.3 | +318 KiB |
| [U.] | srt | 1.5.4 | 1.5.6 | +389 KiB |
| [U.] | steam | 1.0.0.85 | 1.0.0.87 | -108 KiB |
| [U.] | steam-run | 1.0.0.85 | 1.0.0.87 | -116 KiB |
| [U.] | steam-unwrapped | 1.0.0.85 | 1.0.0.87 | +83.6 KiB |
| [U.] | svt-av1 | 3.1.2 | 4.1.0 | -1.09 MiB |
| [U.] | systemd | 260.2 | 261.1 | +65.9 MiB |
| [U.] | systemd-minimal | 260.2 | 261.1 | +3.17 MiB |
| [U.] | systemd-minimal-libs | 260.2 | 261.1 | +465 KiB |
| [U.] | tailscale | 1.98.8 | 1.98.10 | +28.3 KiB |
| [U.] | tzdata | 2026b | 2026c | -18.8 KiB |
| [U.] | unbound | 1.25.1 | 1.25.2 | +8.11 KiB |
| [U.] | unifont | 17.0.04 | 17.0.05 | +168 B |
| [U.] | util-linux | 2.42 | 2.42.2 | +237 KiB |
| [U.] | util-linux-minimal | 2.42 | 2.42.2 | +34.7 KiB |
| [U.] | vim | 9.2.0389 | 9.2.0782 | +202 KiB |
| [U.] | vpnc-scripts-unstable | 2023-01-03 | 2026-06-29 | +1.19 KiB |
| [U.] | vulkan-loader | 1.4.341.0 | 1.4.350.0 | +39.8 KiB |
| [U.] | wayland | 1.25.0 | 1.26.0 | +12.5 KiB |
| [U.] | wayvnc | 0.10.0 | 0.10.1 | +240 B |
| [U.] | webkitgtk | 2.52.4+abi=4.1 | 2.52.5+abi=4.1 | +474 KiB |
| [U.] | which | 2.23 | 2.25 | 0 B |
| [U.] | wlroots | 0.20.1 | 0.20.2 | +48 B |
| [U.] | x265 | 4.1 | 4.2 | +195 KiB |
| [U.] | xfsprogs | 7.0.1 | 7.1.1 | +2.24 KiB |
| [U.] | xgcc | 15.2.0 | 15.3.0 | 0 B |
| [U.] | xkeyboard-config | 2.47 | 2.48 | +13 KiB |
| [U.] | xwayland | 24.1.12 | 24.1.13 | +8 B |
| [U.] | zix | 0.6.2 | 0.8.2 | +10.1 KiB |
| [U.] | zsync | 0.6.3-unstable-2025-05-29 | 0.6.4 | -1.29 KiB |
| [U.] | zxing-cpp | 2.3.0 | 3.0.2 | -198 KiB |

</details>

<details>
<summary><strong>Downgraded</strong> (6)</summary>

| Category | Name | Old Version | New Version | Size |
| --- | --- | --- | --- | --- |
| [D] | bash | 5.3p15 | 5.3p9 | -3.99 KiB |
| [D] | bash-interactive | 5.3p15 | 5.3p9 | -7.98 KiB |
| [D] | gnutls | 3.8.13 | ... | -1.49 MiB |
| [D] | libtpms | 0.10.2-unstable-2026-05-06 | 0.10.2 | +32.7 KiB |
| [D] | polkit | 1.pam | ... | -1.34 KiB |
| [D] | swtpm | 0.10.1-unstable-2026-05-21 | 0.10.1 | +96.2 KiB |

</details>

<details>
<summary><strong>Changed</strong> (45)</summary>

| Category | Name | Version | Size |
| --- | --- | --- | --- |
| [C] | blueman | - | +251 KiB |
| [C] | container-init | - | -132 KiB |
| [C] | exempi | - | -10.1 KiB |
| [C] | fc-cache | - | +17.7 KiB |
| [C] | flac | - | -58.5 KiB |
| [C] | freetype | - | -13.9 KiB |
| [C] | gcr | - | -44.3 KiB |
| [C] | gfxstream | - | -13.3 KiB |
| [C] | ghostscript-with-X | - | -11.9 KiB |
| [C] | glibc | - | -44.5 KiB |
| [C] | gnome-user-share | - | +68.2 KiB |
| [C] | gnutar | 1.35 (2 -> 1), ... | -2.72 MiB |
| [C] | greetd | - | +60.5 KiB |
| [C] | harfbuzz | - | -10.1 KiB |
| [C] | hwdb.bin | - | +88.5 KiB |
| [C] | jemalloc | - | +149 KiB |
| [C] | libdvdread | - | -9.68 KiB |
| [C] | libglycin | - | +261 KiB |
| [C] | libvmaf | - | -20.5 KiB |
| [C] | libxml2 | - | +9.42 KiB |
| [C] | llvm | - | -52.8 KiB |
| [C] | make-initrd-ng | - | +18.3 KiB |
| [C] | man-paths | - | +22.3 KiB |
| [C] | mupdf | - | -12 KiB |
| [C] | networkmanager | - | -16.5 KiB |
| [C] | nixos-configuration-reference-manpage | - | +11.4 KiB |
| [C] | nixos-manual-html | - | +302 KiB |
| [C] | nixos-rebuild-ng | - | +56.8 KiB |
| [C] | nsncd | - | +29.4 KiB |
| [C] | openal-soft | - | -8.7 KiB |
| [C] | openjpeg | - | -10.7 KiB |
| [C] | openvswitch | - | -28.1 KiB |
| [C] | pciutils | - | +58.5 KiB |
| [C] | rutabaga_gfx | - | +1.12 MiB |
| [C] | samba | - | -8.35 KiB |
| [C] | slang | - | -16 KiB |
| [C] | source | - | +2.82 MiB |
| [C] | switch-to-configuration | - | +37.2 KiB |
| [C] | system-path | - | +27.6 KiB |
| [C] | texinfo-interactive | - | -8.23 KiB |
| [C] | thin-provisioning-tools | - | +167 KiB |
| [C] | tpm2-tss | - | -8.3 KiB |
| [C] | tuigreet | - | +73.9 KiB |
| [C] | wshowkeys-mao-git | 184f55dbc5320c34a56d02353410ad35a0f3e090 -> 35d70762ab9af4ea301853e79b3b925d5fe9e920 | +4.58 KiB |
| [C] | xwayland-satellite | - | +987 KiB |

</details>

<details>
<summary><strong>Mixed</strong> (3)</summary>

| Category | Name | Version | Size |
| --- | --- | --- | --- |
| [?] | fuse | 3.17.4-bin -> 3.18.2-bin, 3.17.4-man -> 3.18.2-man, 3.17.4 -> 3.18.2, 2.9.9, ... | -233 KiB |
| [?] | nixos-option | <none> -> 26.11, 26.11_fish-completions | +752 B |
| [?] | procps | 4.0.6_fish-completions -> 4.0.6-doc, 4.0.6-man, ... | -95 KiB |

</details>
